### PR TITLE
Add traccc, main branch (2024.10.31.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+
+# Files created on in-source CMake builds.
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json
+
+# Files created by VSCode builds.
+build/
+out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,10 @@
 # CMAKE_CUDA_ARCHITECTURES <native> requires CMake 3.24.
 cmake_minimum_required(VERSION 3.24)
 
-# Set the architecture to build code for.
-if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  set(CMAKE_CUDA_ARCHITECTURES
-      native
-      CACHE STRING "CUDA architectures to build device code for")
-endif()
-
 project(
   CoScheduler
   VERSION 0.0.1
-  LANGUAGES CXX CUDA)
+  LANGUAGES CXX)
 
 # Require a C++20 compiler for C++.
 set(CMAKE_CXX_STANDARD
@@ -24,11 +17,23 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Require a C++17 support for CUDA.
 set(CMAKE_CUDA_STANDARD
-    17
+    20
     CACHE STRING "The (CUDA) C++ standard to use")
+# Set the architecture to build code for.
+set(CMAKE_CUDA_ARCHITECTURES
+    native
+    CACHE STRING "CUDA architectures to build device code for")
 
+# Enable the CUDA language, now that relevant variables have been set.
+enable_language(CUDA)
+
+# Set up the built-in externals.
+add_subdirectory(externals)
+
+# Find the necessary packages.
 find_package(TBB REQUIRED)
 find_package(CUDAToolkit REQUIRED)
+find_package(traccc REQUIRED)
 
 file(
   GLOB
@@ -42,4 +47,4 @@ file(
 add_executable(CoScheduler ${all_files})
 set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Wextra -g -O0 -fno-omit-frame-pointer -fsanitize=address")
 set(CMAKE_CUDA_FLAGS_DEBUG "-Wall -Wextra -g -O0 -fno-omit-frame-pointer")
-target_link_libraries(CoScheduler PRIVATE TBB::tbb CUDA::cudart)
+target_link_libraries(CoScheduler PRIVATE TBB::tbb CUDA::cudart traccc::core)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -1,0 +1,4 @@
+
+# Set up all necessary external(s).
+add_subdirectory(tbb)
+add_subdirectory(traccc)

--- a/externals/tbb/CMakeLists.txt
+++ b/externals/tbb/CMakeLists.txt
@@ -1,0 +1,21 @@
+
+# CMake include(s).
+cmake_minimum_required( VERSION 3.24 )
+include( FetchContent )
+
+# Tell the user what's happening.
+message( STATUS "Building oneTBB as part of the project" )
+
+# Declare where to get TBB from.
+set( SCHED_TBB_SOURCE
+   "URL;https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.13.0.tar.gz;URL_MD5;f287cd007240a838286ff13e7deaee12"
+   CACHE STRING "Source for TBB, when built as part of this project" )
+mark_as_advanced( SCHED_TBB_SOURCE )
+FetchContent_Declare( TBB ${SCHED_TBB_SOURCE} OVERRIDE_FIND_PACKAGE )
+
+# Options used in the build of TBB.
+set( TBB_TEST FALSE CACHE BOOL "Turn off the TBB tests" )
+set( TBB_STRICT FALSE CACHE BOOL "Do not throw errors on compiler warnings" )
+
+# Get it into the current directory.
+FetchContent_MakeAvailable( TBB )

--- a/externals/tbb/README.md
+++ b/externals/tbb/README.md
@@ -1,0 +1,4 @@
+# Build Instructions for [oneTBB](https://github.com/oneapi-src/oneTBB)
+
+This is a recipe for building the
+[oneTBB](https://github.com/oneapi-src/oneTBB) code as part of this project.

--- a/externals/traccc/CMakeLists.txt
+++ b/externals/traccc/CMakeLists.txt
@@ -1,0 +1,31 @@
+
+# CMake include(s).
+cmake_minimum_required( VERSION 3.24 )
+include( FetchContent )
+
+# Tell the user what's happening.
+message( STATUS "Building traccc as part of the project" )
+
+# Declare where to get traccc from.
+set( SCHED_TRACCC_SOURCE
+   "URL;https://github.com/acts-project/traccc/archive/refs/tags/v0.17.0.tar.gz;URL_MD5;fdfa678dc60005555edd0b9575873fa3"
+   CACHE STRING "Source for traccc, when built as part of this project" )
+mark_as_advanced( SCHED_TRACCC_SOURCE )
+FetchContent_Declare( traccc ${SCHED_TRACCC_SOURCE} OVERRIDE_FIND_PACKAGE )
+
+# Options used in the build of traccc.
+set( TRACCC_BUILD_TESTING FALSE CACHE BOOL
+   "Turn off the build of the traccc unit tests" )
+set( TRACCC_BUILD_BENCHMARKS FALSE CACHE BOOL
+   "Turn off the build of the traccc benchmarks" )
+set( TRACCC_BUILD_EXAMPLES FALSE CACHE BOOL
+   "Turn off the build of the traccc examples" )
+set( TRACCC_USE_ROOT FALSE CACHE BOOL
+   "Don't use ROOT as part of the traccc build" )
+set( TRACCC_SETUP_TBB FALSE CACHE BOOL
+   "Don't set up TBB as part of the traccc build" )
+set( TRACCC_BUILD_CUDA TRUE CACHE BOOL
+   "Turn on the build of traccc::cuda" )
+
+# Get it into the current directory.
+FetchContent_MakeAvailable( traccc )

--- a/externals/traccc/README.md
+++ b/externals/traccc/README.md
@@ -1,0 +1,4 @@
+# Build Instructions for [traccc](https://github.com/acts-project/traccc)
+
+This is a recipe for building the
+[traccc](https://github.com/acts-project/traccc) code as part of this project.

--- a/src/TracccAlgorithm.cpp
+++ b/src/TracccAlgorithm.cpp
@@ -1,0 +1,30 @@
+
+// Local include(s).
+#include "TracccAlgorithm.hpp"
+
+StatusCode TracccAlgorithm::initialize()
+{
+   return StatusCode::SUCCESS;
+}
+
+AlgorithmBase::AlgCoInterface TracccAlgorithm::execute(EventContext /*ctx*/) const
+{
+   co_return StatusCode::SUCCESS;
+}
+
+StatusCode TracccAlgorithm::finalize()
+{
+   return StatusCode::SUCCESS;
+}
+
+const std::vector<std::string> &TracccAlgorithm::dependencies() const
+{
+   static std::vector<std::string> deps = {};
+   return deps;
+}
+
+const std::vector<std::string> &TracccAlgorithm::products() const
+{
+   static std::vector<std::string> prods = {};
+   return prods;
+}

--- a/src/TracccAlgorithm.hpp
+++ b/src/TracccAlgorithm.hpp
@@ -1,0 +1,40 @@
+
+#pragma once
+
+// Local include(s).
+#include "AlgorithmBase.hpp"
+#include "EventContext.hpp"
+
+// traccc include(s).
+#include <traccc/clusterization/clusterization_algorithm.hpp>
+#include <vecmem/memory/host_memory_resource.hpp>
+
+/// Algorithm making use of traccc
+class TracccAlgorithm : public AlgorithmBase
+{
+
+public:
+   /// @name Function(s) inherited from @c AlgorithmBase
+   /// @{
+
+   /// Initialize the algorithm
+   virtual StatusCode initialize() override;
+   /// Execute the algorithm
+   virtual AlgCoInterface execute(EventContext ctx) const override;
+   /// Finalize the algorithm
+   virtual StatusCode finalize() override;
+
+   /// List the dependencies of the algorithm
+   virtual const std::vector<std::string> &dependencies() const = 0;
+   /// List the products of the algorithm
+   virtual const std::vector<std::string> &products() const = 0;
+
+   /// @}
+
+private:
+   /// (Host) memory resource to use in the clusterization algorithm
+   vecmem::host_memory_resource m_mr;
+   /// The traccc clusterization algorithm
+   traccc::host::clusterization_algorithm m_clusterization{m_mr};
+
+}; // class TracccAlgorithm


### PR DESCRIPTION
Added the ability to use [traccc](https://github.com/acts-project/traccc) in the project, by teaching the project how to build the [traccc](https://github.com/acts-project/traccc) project along with the rest of its code.

Added a demonstrator algorithm (`TracccAlgorithm`) for making use of a [traccc](https://github.com/acts-project/traccc) algorithm (`traccc::host::clusterization_algorithm`) inside of an algorithm of this project.