### PR TITLE
Rehaul of the coroutine base sheduler: documentation, testability, races fixes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ if(BUILD_TRACCC)
 endif()
 
 # Add the tests.
-
+enable_testing()
 if(BUILD_TESTS)
   add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,18 @@ if(BUILD_TRACCC)
   target_link_libraries(schedule_traccc PRIVATE CoScheduler components_traccc)
 endif()
 
+# Copy the simple_scheduler_scan.sh script to the bin directory and make it executable
+add_custom_command(
+  OUTPUT ${CMAKE_BINARY_DIR}/bin/simple_scheduler_scan.sh
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/bin/simple_scheduler_scan.sh ${CMAKE_BINARY_DIR}/bin/simple_scheduler_scan.sh
+  DEPENDS ${CMAKE_SOURCE_DIR}/bin/simple_scheduler_scan.sh
+  COMMENT "Copying and setting executable permissions for simple_scheduler_scan.sh"
+)
+
+add_custom_target(copy_simple_scheduler_scan ALL
+  DEPENDS ${CMAKE_BINARY_DIR}/bin/simple_scheduler_scan.sh
+)
+
 # Add the tests.
 enable_testing()
 if(BUILD_TESTS)

--- a/README.md
+++ b/README.md
@@ -24,13 +24,43 @@ cmake --build build
 
 Then run the executables:
 
+The simple test:
 ```sh
 build/bin/schedule_simple
 ```
 
-or
+or the traccc test:
+
+The data should be downloaded (once) in the build tree by running `build/_deps/traccc-src/data/traccc_data_get_files.sh`
+This will download the data in-place in the script's directory. Then run the test:
 
 ```sh
-TRACCC_TEST_DATA_DIR=<path_to_traccc_data> build/bin/schedule_traccc
+TRACCC_TEST_DATA_DIR=build/_deps/traccc-src/data/ ./build/bin/schedule_traccc
 ```
 
+The download instructions for the traccc data are [in the traccc readme](https://github.com/acts-project/traccc?tab=readme-ov-file#getting-started)
+
+```sh
+git clone https://github.com/acts-project/traccc.git
+./traccc/data/traccc_data_get_files.sh
+```
+
+# Traccc 101
+
+Traccc is a framework agnostic algorithm.
+Gaudi is the framework (services, algorithms tools, orchestrator), based on TBB
+Athena is a framework based on Gaudi, but re-implements parts of it.
+
+## Gaudi modules
+
+States see wp1.7-scheduler-tests/src/AlgExecState.hpp (suspened is a new addition)
+
+### Dependencies
+
+- Each algo defined data dependency (like in CMS)
+- Sequencers are algos or modules that can have sub-algo or sub-modules that express additional non-data dependency
+  - Sometimes data dependency is not fully expressed
+  - Sequencers also express filtering
+
+
+Here only data dependency. In Gaudi statuses are different depending we wait for data or non data dependency.

--- a/bin/schedule_simple.cpp
+++ b/bin/schedule_simple.cpp
@@ -13,26 +13,29 @@
 void printHelp() {
     std::cout << "Usage: schedule_simple [options]\n"
               << "Options:\n"
-              << "  --threads <N>       Set the number of threads (default: 4)\n"
-              << "  --streams <N>       Set the number of CUDA streams (default: 4)\n"
-              << "  --error-on          Enable error in FirstAlgorithm (default: off)\n"
-              << "  --error-event <N>   Set the event ID where the error occurs (default: -1)\n"
-              << "  --verbose           Enable verbose output (default: off)\n"
-              << "  --help              Show this help message\n";
+              << "  -t, --threads <N>       Set the number of threads (default: 4)\n"
+              << "  -s, --streams <N>       Set the number of CUDA streams (default: 4)\n"
+              << "  -e, --events <N>        Set the number of events to process (default: 500)\n"
+              << "  -o, --error-on          Enable error in FirstAlgorithm (default: off)\n"
+              << "  -n, --error-event <N>   Set the event ID where the error occurs (default: -1)\n"
+              << "  -v, --verbose           Enable verbose output (default: off)\n"
+              << "  -h, --help              Show this help message\n";
 }
 
 int main(int argc, char* argv[]) {
-    int threads = 4; // Default number of threads
-    int streams = 4; // Default number of streams
+    int threads = 4;       // Default number of threads
+    int streams = 4;       // Default number of streams
+    int events = 500;      // Default number of events
     bool errorEnabled = false; // Default: no error
     int errorEventId = -1; // Default: no specific event for error
-    bool verbose = false; // Default: no verbose output
+    bool verbose = false;  // Default: no verbose output
 
     // Define long options
     static struct option long_options[] = {
         {"threads", required_argument, nullptr, 't'},
         {"streams", required_argument, nullptr, 's'},
-        {"error-on", no_argument, nullptr, 'e'},
+        {"events", required_argument, nullptr, 'e'},
+        {"error-on", no_argument, nullptr, 'o'},
         {"error-event", required_argument, nullptr, 'n'},
         {"verbose", no_argument, nullptr, 'v'},
         {"help", no_argument, nullptr, 'h'},
@@ -41,7 +44,7 @@ int main(int argc, char* argv[]) {
 
     // Parse command-line arguments
     int opt;
-    while ((opt = getopt_long(argc, argv, "t:s:en:vh", long_options, nullptr)) != -1) {
+    while ((opt = getopt_long(argc, argv, "t:s:e:on:vh", long_options, nullptr)) != -1) {
         switch (opt) {
             case 't':
                 threads = std::stoi(optarg);
@@ -50,6 +53,9 @@ int main(int argc, char* argv[]) {
                 streams = std::stoi(optarg);
                 break;
             case 'e':
+                events = std::stoi(optarg);
+                break;
+            case 'o':
                 errorEnabled = true;
                 break;
             case 'n':
@@ -68,13 +74,13 @@ int main(int argc, char* argv[]) {
     }
 
     // Print configuration
-    std::cout << "Starting scheduler with " << threads << " threads and " << streams << " streams.\n";
+    std::cout << "Starting scheduler with " << threads << " threads, " << streams << " streams, and " << events << " events.\n";
     std::cout << "Error in FirstAlgorithm: " << (errorEnabled ? "enabled" : "disabled")
               << ", event ID: " << errorEventId << "\n";
     std::cout << "Verbose output: " << (verbose ? "enabled" : "disabled") << "\n";
 
     // Initialize the scheduler
-    Scheduler scheduler(/*events=*/500, threads, streams);
+    Scheduler scheduler(events, threads, streams);
 
     // Create the algorithms
     FirstAlgorithm firstAlgorithm(errorEnabled, errorEventId, verbose);

--- a/bin/schedule_simple.cpp
+++ b/bin/schedule_simple.cpp
@@ -3,7 +3,6 @@
 #include <cstdlib>
 #include <getopt.h> // For command-line argument parsing
 #include "Scheduler.hpp"
-#include "StatusCode.hpp"
 #include "FirstAlgorithm.hpp"
 #include "SecondAlgorithm.hpp"
 #include "ThirdAlgorithm.hpp"
@@ -18,6 +17,7 @@ void printHelp() {
               << "  --streams <N>       Set the number of CUDA streams (default: 4)\n"
               << "  --error-on          Enable error in FirstAlgorithm (default: off)\n"
               << "  --error-event <N>   Set the event ID where the error occurs (default: -1)\n"
+              << "  --verbose           Enable verbose output (default: off)\n"
               << "  --help              Show this help message\n";
 }
 
@@ -26,6 +26,7 @@ int main(int argc, char* argv[]) {
     int streams = 4; // Default number of streams
     bool errorEnabled = false; // Default: no error
     int errorEventId = -1; // Default: no specific event for error
+    bool verbose = false; // Default: no verbose output
 
     // Define long options
     static struct option long_options[] = {
@@ -33,13 +34,14 @@ int main(int argc, char* argv[]) {
         {"streams", required_argument, nullptr, 's'},
         {"error-on", no_argument, nullptr, 'e'},
         {"error-event", required_argument, nullptr, 'n'},
+        {"verbose", no_argument, nullptr, 'v'},
         {"help", no_argument, nullptr, 'h'},
         {nullptr, 0, nullptr, 0}
     };
 
     // Parse command-line arguments
     int opt;
-    while ((opt = getopt_long(argc, argv, "t:s:en:h", long_options, nullptr)) != -1) {
+    while ((opt = getopt_long(argc, argv, "t:s:en:vh", long_options, nullptr)) != -1) {
         switch (opt) {
             case 't':
                 threads = std::stoi(optarg);
@@ -52,6 +54,9 @@ int main(int argc, char* argv[]) {
                 break;
             case 'n':
                 errorEventId = std::stoi(optarg);
+                break;
+            case 'v':
+                verbose = true;
                 break;
             case 'h':
                 printHelp();
@@ -66,14 +71,15 @@ int main(int argc, char* argv[]) {
     std::cout << "Starting scheduler with " << threads << " threads and " << streams << " streams.\n";
     std::cout << "Error in FirstAlgorithm: " << (errorEnabled ? "enabled" : "disabled")
               << ", event ID: " << errorEventId << "\n";
+    std::cout << "Verbose output: " << (verbose ? "enabled" : "disabled") << "\n";
 
     // Initialize the scheduler
     Scheduler scheduler(/*events=*/500, threads, streams);
 
     // Create the algorithms
-    FirstAlgorithm firstAlgorithm(errorEnabled, errorEventId);
-    SecondAlgorithm secondAlgorithm;
-    ThirdAlgorithm thirdAlgorithm;
+    FirstAlgorithm firstAlgorithm(errorEnabled, errorEventId, verbose);
+    SecondAlgorithm secondAlgorithm(verbose);
+    ThirdAlgorithm thirdAlgorithm(verbose);
 
     // Add the algorithms to the scheduler
     scheduler.addAlgorithm(firstAlgorithm);

--- a/bin/schedule_simple.cpp
+++ b/bin/schedule_simple.cpp
@@ -7,6 +7,8 @@
 #include "SecondAlgorithm.hpp"
 #include "ThirdAlgorithm.hpp"
 
+// Add pragma to suppress optimization for debugging purposes.
+#pragma GCC optimize ("O0")
 
 int main() {
   // Create the scheduler.
@@ -23,6 +25,7 @@ int main() {
   scheduler.addAlgorithm(thirdAlgorithm);
 
   // Run the scheduler.
-  std::cout << (scheduler.run().what()) << std::endl;
+  auto w = scheduler.run().what();
+  std::cout << "Final scheduler status: " << w << std::endl;
   return EXIT_SUCCESS;
 }

--- a/bin/schedule_simple.cpp
+++ b/bin/schedule_simple.cpp
@@ -14,32 +14,44 @@
 void printHelp() {
     std::cout << "Usage: schedule_simple [options]\n"
               << "Options:\n"
-              << "  --threads <N>    Set the number of threads (default: 4)\n"
-              << "  --streams <N>    Set the number of CUDA streams (default: 4)\n"
-              << "  --help           Show this help message\n";
+              << "  --threads <N>       Set the number of threads (default: 4)\n"
+              << "  --streams <N>       Set the number of CUDA streams (default: 4)\n"
+              << "  --error-on          Enable error in FirstAlgorithm (default: off)\n"
+              << "  --error-event <N>   Set the event ID where the error occurs (default: -1)\n"
+              << "  --help              Show this help message\n";
 }
 
 int main(int argc, char* argv[]) {
     int threads = 4; // Default number of threads
     int streams = 4; // Default number of streams
+    bool errorEnabled = false; // Default: no error
+    int errorEventId = -1; // Default: no specific event for error
 
     // Define long options
     static struct option long_options[] = {
         {"threads", required_argument, nullptr, 't'},
         {"streams", required_argument, nullptr, 's'},
+        {"error-on", no_argument, nullptr, 'e'},
+        {"error-event", required_argument, nullptr, 'n'},
         {"help", no_argument, nullptr, 'h'},
         {nullptr, 0, nullptr, 0}
     };
 
     // Parse command-line arguments
     int opt;
-    while ((opt = getopt_long(argc, argv, "t:s:h", long_options, nullptr)) != -1) {
+    while ((opt = getopt_long(argc, argv, "t:s:en:h", long_options, nullptr)) != -1) {
         switch (opt) {
             case 't':
                 threads = std::stoi(optarg);
                 break;
             case 's':
                 streams = std::stoi(optarg);
+                break;
+            case 'e':
+                errorEnabled = true;
+                break;
+            case 'n':
+                errorEventId = std::stoi(optarg);
                 break;
             case 'h':
                 printHelp();
@@ -52,12 +64,14 @@ int main(int argc, char* argv[]) {
 
     // Print configuration
     std::cout << "Starting scheduler with " << threads << " threads and " << streams << " streams.\n";
+    std::cout << "Error in FirstAlgorithm: " << (errorEnabled ? "enabled" : "disabled")
+              << ", event ID: " << errorEventId << "\n";
 
     // Initialize the scheduler
     Scheduler scheduler(/*events=*/500, threads, streams);
 
     // Create the algorithms
-    FirstAlgorithm firstAlgorithm;
+    FirstAlgorithm firstAlgorithm(errorEnabled, errorEventId);
     SecondAlgorithm secondAlgorithm;
     ThirdAlgorithm thirdAlgorithm;
 

--- a/bin/schedule_traccc.cpp
+++ b/bin/schedule_traccc.cpp
@@ -20,6 +20,7 @@ int main() {
    scheduler.addAlgorithm(computeAlg);
 
    // Run the scheduler.
-   std::cout << (scheduler.run().what()) << std::endl;
+   auto w = scheduler.run().what();
+   std::cout << w << std::endl;
    return EXIT_SUCCESS;
 }

--- a/bin/simple_scheduler_scan.sh
+++ b/bin/simple_scheduler_scan.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# filepath: /home/cano/NGT/wp1.7-scheduler-tests/bin/simple_scheduler_scan.sh
+
+# Determine the directory where the script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Binary to execute (relative to the script's directory)
+BINARY="$SCRIPT_DIR/schedule_simple"
+
+# Number of events for each run
+EVENTS=2000
+
+# Output CSV header
+echo "Slots,Threads,Bandwidth (events/sec)"
+
+# Loop over threads (1 to 10)
+for THREADS in {1..10}; do
+    # Loop over slots (5 to 50, step 5)
+    for SLOTS in $(seq 5 5 50); do
+        # Run the binary and capture the output
+        OUTPUT=$($BINARY --events $EVENTS --threads $THREADS --streams $SLOTS 2>&1)
+
+        # Extract the bandwidth from the output
+        BANDWIDTH=$(echo "$OUTPUT" | grep -oP '(?<=\().*?(?= events/sec)' | awk '{print $1}')
+
+        # Print the result in CSV format
+        echo "$SLOTS,$THREADS,$BANDWIDTH"
+    done
+done

--- a/components/simple/CudaKernels.cu
+++ b/components/simple/CudaKernels.cu
@@ -1,42 +1,41 @@
 #include <cstdio>
 #include <ctime>
 #include <iostream>
+#include <cstdint>
 
 #include "CudaKernels.cuh"
 
 
-static __device__ void run_until_modulo(int mod) {
-   while(true) {
-      auto current = std::clock();
-      if(current % mod == 0) {
-         return;
-      }
-   }
+static __device__ void nanospin(uint64_t ns) {
+   uint64_t start = std::clock();
+   constexpr uint64_t cps = 1'400'000'000; // Assuming 1.4 GHz clock rate
+   uint64_t end = start + ((ns * cps) / 1'000'000'000);
+   while(std::clock() < end);
 }
 
 
 static __global__ void testKernel1() {
-   run_until_modulo(71);
+   nanospin(20'000); // Spin for 20 microseconds
 }
 
 
 static __global__ void testKernel2() {
-   run_until_modulo(72);
+   nanospin(25'000);
 }
 
 
 static __global__ void testKernel3() {
-   run_until_modulo(73);
+   nanospin(30'000);
 }
 
 
 static __global__ void testKernel4() {
-   run_until_modulo(74);
+   nanospin(35'000);
 }
 
 
 static __global__ void testKernel5() {
-   run_until_modulo(75);
+   nanospin(40'000);
 }
 
 

--- a/components/simple/CudaKernels.cu
+++ b/components/simple/CudaKernels.cu
@@ -40,30 +40,30 @@ static __global__ void testKernel5() {
 
 
 void launchTestKernel1(cudaStream_t stream) {
-   std::cout << __func__ << std::endl;
+   // std::cout << __func__ << std::endl;
    testKernel1<<<2, 2, 0, stream>>>();
 }
 
 
 void launchTestKernel2(cudaStream_t stream) {
-   std::cout << __func__ << std::endl;
+   // std::cout << __func__ << std::endl;
    testKernel2<<<2, 2, 0, stream>>>();
 }
 
 
 void launchTestKernel3(cudaStream_t stream) {
-   std::cout << __func__ << std::endl;
+   // std::cout << __func__ << std::endl;
    testKernel3<<<2, 2, 0, stream>>>();
 }
 
 
 void launchTestKernel4(cudaStream_t stream) {
-   std::cout << __func__ << std::endl;
+   // std::cout << __func__ << std::endl;
    testKernel4<<<2, 2, 0, stream>>>();
 }
 
 
 void launchTestKernel5(cudaStream_t stream) {
-   std::cout << __func__ << std::endl;
+   // std::cout << __func__ << std::endl;
    testKernel5<<<2, 2, 0, stream>>>();
 }

--- a/components/simple/FirstAlgorithm.cpp
+++ b/components/simple/FirstAlgorithm.cpp
@@ -12,56 +12,66 @@
 #include "../../tests/NVTXUtils.hpp"
 using WP17Scheduler::NVTXUtils::nvtxcolor;
 
-FirstAlgorithm::FirstAlgorithm(bool errorEnabled, int errorEventId)
-    : m_errorEnabled(errorEnabled), m_errorEventId(errorEventId) {}
+FirstAlgorithm::FirstAlgorithm(bool errorEnabled, int errorEventId, bool verbose)
+    : m_errorEnabled(errorEnabled), m_errorEventId(errorEventId), m_verbose(verbose) {}
 
 StatusCode FirstAlgorithm::initialize() {
-   nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(FirstAlgorithm)};
-   SC_CHECK(AlgorithmBase::addProduct<int>("Object1"));
-   SC_CHECK(AlgorithmBase::addProduct<int>("Object2"));
-   std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) << std::endl;
-   return StatusCode::SUCCESS;
+    nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(FirstAlgorithm)};
+    SC_CHECK(AlgorithmBase::addProduct<int>("Object1"));
+    SC_CHECK(AlgorithmBase::addProduct<int>("Object2"));
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) << std::endl;
+    }
+    return StatusCode::SUCCESS;
 }
 
 AlgorithmBase::AlgCoInterface FirstAlgorithm::execute(EventContext ctx) const {
-   std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1 start, " << ctx.info() << " tid=" << gettid() << std::endl;
-   auto range1 = std::make_unique<nvtx3::unique_range>(MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1, " + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{gettid()});
-   auto output1 = std::make_unique<int>(-1);
-   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output1), AlgorithmBase::products()[0]));
-   auto output2 = std::make_unique<int>(-1);
-   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output2), AlgorithmBase::products()[1]));
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1 start, " << ctx.info() << " tid=" << gettid() << std::endl;
+    }
+    auto range1 = std::make_unique<nvtx3::unique_range>(MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1, " + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{gettid()});
+    auto output1 = std::make_unique<int>(-1);
+    SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output1), AlgorithmBase::products()[0]));
+    auto output2 = std::make_unique<int>(-1);
+    SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output2), AlgorithmBase::products()[1]));
 
-   // Inject error if enabled
-   if(m_errorEnabled && ctx.eventNumber == m_errorEventId) {
-      StatusCode status{StatusCode::FAILURE, "FirstAlgorithm execute failed"};
-      status.appendMsg("context event number: " + std::to_string(ctx.eventNumber));
-      status.appendMsg("context slot number: " + std::to_string(ctx.slotNumber));
-      range1.reset();
-      co_return status;
-   }
-   
-   ctx.scheduler->setCudaSlotState(ctx.slotNumber, 0, false);
-   launchTestKernel1(ctx.stream);
-   cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 0});
-   auto r1 = std::move(range1);
-   range1.reset();
-   std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1 end, " << ctx.info() << " tid=" << gettid() << std::endl;
-   co_yield StatusCode::SUCCESS;
+    // Inject error if enabled
+    if (m_errorEnabled && ctx.eventNumber == m_errorEventId) {
+        StatusCode status{StatusCode::FAILURE, "FirstAlgorithm execute failed"};
+        status.appendMsg("context event number: " + std::to_string(ctx.eventNumber));
+        status.appendMsg("context slot number: " + std::to_string(ctx.slotNumber));
+        range1.reset();
+        co_return status;
+    }
 
-   auto range2 = std::make_unique<nvtx3::unique_range>(MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part2, " + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{gettid()});
-   std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part2, " << ctx.info() << std::endl;
-   ctx.scheduler->setCudaSlotState(ctx.slotNumber, 0, false);
-   launchTestKernel2(ctx.stream);
-   cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 0});
-   range2.reset();
-   // Suspend the coroutine until the kernel is finished.
-   co_yield StatusCode::SUCCESS;
-   auto range3 = std::make_unique<nvtx3::unique_range>(MEMBER_FUNCTION_NAME(FirstAlgorithm) + " conclusion, " + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{gettid()});
-   co_return StatusCode::SUCCESS;
+    ctx.scheduler->setCudaSlotState(ctx.slotNumber, 0, false);
+    launchTestKernel1(ctx.stream);
+    cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 0});
+    auto r1 = std::move(range1);
+    range1.reset();
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1 end, " << ctx.info() << " tid=" << gettid() << std::endl;
+    }
+    co_yield StatusCode::SUCCESS;
+
+    auto range2 = std::make_unique<nvtx3::unique_range>(MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part2, " + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{gettid()});
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part2, " << ctx.info() << std::endl;
+    }
+    ctx.scheduler->setCudaSlotState(ctx.slotNumber, 0, false);
+    launchTestKernel2(ctx.stream);
+    cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 0});
+    range2.reset();
+    co_yield StatusCode::SUCCESS;
+
+    auto range3 = std::make_unique<nvtx3::unique_range>(MEMBER_FUNCTION_NAME(FirstAlgorithm) + " conclusion, " + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{gettid()});
+    co_return StatusCode::SUCCESS;
 }
 
 StatusCode FirstAlgorithm::finalize() {
-   nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(FirstAlgorithm)};
-   std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) << std::endl;
-   return StatusCode::SUCCESS;
+    nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(FirstAlgorithm)};
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) << std::endl;
+    }
+    return StatusCode::SUCCESS;
 }

--- a/components/simple/FirstAlgorithm.cpp
+++ b/components/simple/FirstAlgorithm.cpp
@@ -9,9 +9,12 @@
 #include "EventStore.hpp"
 #include "MemberFunctionName.hpp"
 #include "Scheduler.hpp"
+#include "../../tests/NVTXUtils.hpp"
+using WP17Scheduler::NVTXUtils::nvtxcolor;
 
 
 StatusCode FirstAlgorithm::initialize() {
+   nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(FirstAlgorithm)};
    SC_CHECK(AlgorithmBase::addProduct<int>("Object1"));
    SC_CHECK(AlgorithmBase::addProduct<int>("Object2"));
    std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) << std::endl;
@@ -20,6 +23,7 @@ StatusCode FirstAlgorithm::initialize() {
 
 
 AlgorithmBase::AlgCoInterface FirstAlgorithm::execute(EventContext ctx) const {
+   nvtx3::unique_range range1{MEMBER_FUNCTION_NAME(FirstAlgorithm) + " (1)", nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
    auto output1 = std::make_unique<int>(-1);
    SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output1), AlgorithmBase::products()[0]));
    auto output2 = std::make_unique<int>(-1);
@@ -29,17 +33,20 @@ AlgorithmBase::AlgCoInterface FirstAlgorithm::execute(EventContext ctx) const {
    std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1, " << ctx.info() << std::endl;
 
    if(++count == 50) {
+      auto r1 = std::move(range1);
       StatusCode status{StatusCode::FAILURE, "FirstAlgorithm execute failed"};
       status.appendMsg("context event number: " + std::to_string(ctx.eventNumber));
       status.appendMsg("context slot number: " + std::to_string(ctx.slotNumber));
       co_return status;
    } else {
+      auto r1 = std::move(range1);
       ctx.scheduler->setCudaSlotState(ctx.slotNumber, 0, false);
       launchTestKernel1(ctx.stream);
       cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 0});
       co_yield StatusCode::SUCCESS;
    }
 
+   nvtx3::scoped_range range2{MEMBER_FUNCTION_NAME(FirstAlgorithm) + " (2)", nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
    std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part2, " << ctx.info() << std::endl;
    ctx.scheduler->setCudaSlotState(ctx.slotNumber, 0, false);
    launchTestKernel2(ctx.stream);
@@ -50,6 +57,7 @@ AlgorithmBase::AlgCoInterface FirstAlgorithm::execute(EventContext ctx) const {
 
 
 StatusCode FirstAlgorithm::finalize() {
+   nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(FirstAlgorithm)};
    std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) << std::endl;
    return StatusCode::SUCCESS;
 }

--- a/components/simple/FirstAlgorithm.cpp
+++ b/components/simple/FirstAlgorithm.cpp
@@ -21,9 +21,9 @@ StatusCode FirstAlgorithm::initialize() {
 
 AlgorithmBase::AlgCoInterface FirstAlgorithm::execute(EventContext ctx) const {
    auto output1 = std::make_unique<int>(-1);
-   SC_CHECK_YIELD(eventStoreOf(ctx).record(std::move(output1), AlgorithmBase::products()[0]));
+   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output1), AlgorithmBase::products()[0]));
    auto output2 = std::make_unique<int>(-1);
-   SC_CHECK_YIELD(eventStoreOf(ctx).record(std::move(output2), AlgorithmBase::products()[1]));
+   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output2), AlgorithmBase::products()[1]));
 
    static std::atomic_int count = 0;
    std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1, " << ctx.info() << std::endl;

--- a/components/simple/FirstAlgorithm.cpp
+++ b/components/simple/FirstAlgorithm.cpp
@@ -12,6 +12,8 @@
 #include "../../tests/NVTXUtils.hpp"
 using WP17Scheduler::NVTXUtils::nvtxcolor;
 
+FirstAlgorithm::FirstAlgorithm(bool errorEnabled, int errorEventId)
+    : m_errorEnabled(errorEnabled), m_errorEventId(errorEventId) {}
 
 StatusCode FirstAlgorithm::initialize() {
    nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(FirstAlgorithm)};
@@ -21,7 +23,6 @@ StatusCode FirstAlgorithm::initialize() {
    return StatusCode::SUCCESS;
 }
 
-
 AlgorithmBase::AlgCoInterface FirstAlgorithm::execute(EventContext ctx) const {
    std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1 start, " << ctx.info() << " tid=" << gettid() << std::endl;
    auto range1 = std::make_unique<nvtx3::unique_range>(MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1, " + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{gettid()});
@@ -30,22 +31,22 @@ AlgorithmBase::AlgCoInterface FirstAlgorithm::execute(EventContext ctx) const {
    auto output2 = std::make_unique<int>(-1);
    SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output2), AlgorithmBase::products()[1]));
 
-   static std::atomic_int count = 0;
-   if(++count == 50) {
+   // Inject error if enabled
+   if(m_errorEnabled && ctx.eventNumber == m_errorEventId) {
       StatusCode status{StatusCode::FAILURE, "FirstAlgorithm execute failed"};
       status.appendMsg("context event number: " + std::to_string(ctx.eventNumber));
       status.appendMsg("context slot number: " + std::to_string(ctx.slotNumber));
       range1.reset();
       co_return status;
-   } else {
-      ctx.scheduler->setCudaSlotState(ctx.slotNumber, 0, false);
-      launchTestKernel1(ctx.stream);
-      cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 0});
-      auto r1 = std::move(range1);
-      range1.reset();
-      std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1 end, " << ctx.info() << " tid=" << gettid() << std::endl;
-      co_yield StatusCode::SUCCESS;
    }
+   
+   ctx.scheduler->setCudaSlotState(ctx.slotNumber, 0, false);
+   launchTestKernel1(ctx.stream);
+   cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 0});
+   auto r1 = std::move(range1);
+   range1.reset();
+   std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1 end, " << ctx.info() << " tid=" << gettid() << std::endl;
+   co_yield StatusCode::SUCCESS;
 
    auto range2 = std::make_unique<nvtx3::unique_range>(MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part2, " + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{gettid()});
    std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part2, " << ctx.info() << std::endl;
@@ -58,7 +59,6 @@ AlgorithmBase::AlgCoInterface FirstAlgorithm::execute(EventContext ctx) const {
    auto range3 = std::make_unique<nvtx3::unique_range>(MEMBER_FUNCTION_NAME(FirstAlgorithm) + " conclusion, " + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{gettid()});
    co_return StatusCode::SUCCESS;
 }
-
 
 StatusCode FirstAlgorithm::finalize() {
    nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(FirstAlgorithm)};

--- a/components/simple/FirstAlgorithm.cpp
+++ b/components/simple/FirstAlgorithm.cpp
@@ -23,35 +23,37 @@ StatusCode FirstAlgorithm::initialize() {
 
 
 AlgorithmBase::AlgCoInterface FirstAlgorithm::execute(EventContext ctx) const {
-   nvtx3::unique_range range1{MEMBER_FUNCTION_NAME(FirstAlgorithm) + " (1)", nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
+   std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1 start, " << ctx.info() << " tid=" << gettid() << std::endl;
+   auto range1 = std::make_unique<nvtx3::unique_range>(MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1, " + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{gettid()});
    auto output1 = std::make_unique<int>(-1);
    SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output1), AlgorithmBase::products()[0]));
    auto output2 = std::make_unique<int>(-1);
    SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output2), AlgorithmBase::products()[1]));
 
    static std::atomic_int count = 0;
-   std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1, " << ctx.info() << std::endl;
-
    if(++count == 50) {
-      auto r1 = std::move(range1);
       StatusCode status{StatusCode::FAILURE, "FirstAlgorithm execute failed"};
       status.appendMsg("context event number: " + std::to_string(ctx.eventNumber));
       status.appendMsg("context slot number: " + std::to_string(ctx.slotNumber));
+      range1.reset();
       co_return status;
    } else {
-      auto r1 = std::move(range1);
       ctx.scheduler->setCudaSlotState(ctx.slotNumber, 0, false);
       launchTestKernel1(ctx.stream);
       cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 0});
+      auto r1 = std::move(range1);
+      range1.reset();
+      std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part1 end, " << ctx.info() << " tid=" << gettid() << std::endl;
       co_yield StatusCode::SUCCESS;
    }
 
-   nvtx3::scoped_range range2{MEMBER_FUNCTION_NAME(FirstAlgorithm) + " (2)", nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
+   auto range2 = std::make_unique<nvtx3::unique_range>(MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part2, " + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{gettid()});
    std::cout << MEMBER_FUNCTION_NAME(FirstAlgorithm) + " part2, " << ctx.info() << std::endl;
    ctx.scheduler->setCudaSlotState(ctx.slotNumber, 0, false);
    launchTestKernel2(ctx.stream);
    cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 0});
    cudaStreamSynchronize(ctx.stream);
+   range2.reset();
    co_return StatusCode::SUCCESS;
 }
 

--- a/components/simple/FirstAlgorithm.cpp
+++ b/components/simple/FirstAlgorithm.cpp
@@ -52,8 +52,10 @@ AlgorithmBase::AlgCoInterface FirstAlgorithm::execute(EventContext ctx) const {
    ctx.scheduler->setCudaSlotState(ctx.slotNumber, 0, false);
    launchTestKernel2(ctx.stream);
    cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 0});
-   cudaStreamSynchronize(ctx.stream);
    range2.reset();
+   // Suspend the coroutine until the kernel is finished.
+   co_yield StatusCode::SUCCESS;
+   auto range3 = std::make_unique<nvtx3::unique_range>(MEMBER_FUNCTION_NAME(FirstAlgorithm) + " conclusion, " + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{gettid()});
    co_return StatusCode::SUCCESS;
 }
 

--- a/components/simple/FirstAlgorithm.hpp
+++ b/components/simple/FirstAlgorithm.hpp
@@ -6,8 +6,8 @@
 
 class FirstAlgorithm : public AlgorithmBase {
 public:
-    // Constructor with optional error parameters
-    FirstAlgorithm(bool errorEnabled = false, int errorEventId = -1);
+    // Constructor with verbose and error parameters
+    FirstAlgorithm(bool errorEnabled = false, int errorEventId = -1, bool verbose = false);
 
     StatusCode initialize() override;
     AlgCoInterface execute(EventContext ctx) const override;
@@ -16,4 +16,5 @@ public:
 private:
     bool m_errorEnabled;  // Whether the error is enabled
     int m_errorEventId;   // Event ID where the error occurs
+    bool m_verbose;       // Whether verbose output is enabled
 };

--- a/components/simple/FirstAlgorithm.hpp
+++ b/components/simple/FirstAlgorithm.hpp
@@ -6,7 +6,14 @@
 
 class FirstAlgorithm : public AlgorithmBase {
 public:
-   virtual StatusCode initialize() override;
-   virtual AlgCoInterface execute(EventContext ctx) const override;
-   virtual StatusCode finalize() override;
+    // Constructor with optional error parameters
+    FirstAlgorithm(bool errorEnabled = false, int errorEventId = -1);
+
+    StatusCode initialize() override;
+    AlgCoInterface execute(EventContext ctx) const override;
+    StatusCode finalize() override;
+
+private:
+    bool m_errorEnabled;  // Whether the error is enabled
+    int m_errorEventId;   // Event ID where the error occurs
 };

--- a/components/simple/SecondAlgorithm.cpp
+++ b/components/simple/SecondAlgorithm.cpp
@@ -19,9 +19,9 @@ StatusCode SecondAlgorithm::initialize() {
 
 AlgorithmBase::AlgCoInterface SecondAlgorithm::execute(EventContext ctx) const {
    const int* input = nullptr;
-   SC_CHECK_YIELD(eventStoreOf(ctx).retrieve(input, AlgorithmBase::dependencies()[0]));
+   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).retrieve(input, AlgorithmBase::dependencies()[0]));
    auto output = std::make_unique<int>(-1);
-   SC_CHECK_YIELD(eventStoreOf(ctx).record(std::move(output), AlgorithmBase::products()[0]));
+   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output), AlgorithmBase::products()[0]));
 
    std::cout << MEMBER_FUNCTION_NAME(SecondAlgorithm) + " part1, " << ctx.info() << std::endl;
    ctx.scheduler->setCudaSlotState(ctx.slotNumber, 1, false);

--- a/components/simple/SecondAlgorithm.cpp
+++ b/components/simple/SecondAlgorithm.cpp
@@ -39,7 +39,10 @@ AlgorithmBase::AlgCoInterface SecondAlgorithm::execute(EventContext ctx) const {
    ctx.scheduler->setCudaSlotState(ctx.slotNumber, 1, false);
    launchTestKernel4(ctx.stream);
    cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 1});
-   cudaStreamSynchronize(ctx.stream);
+   // Suspend the coroutine until the kernel is finished.
+   { auto r2 = std::move(range2); } // End range
+   co_yield StatusCode::SUCCESS;
+   auto range3 = nvtx3::scoped_range{MEMBER_FUNCTION_NAME(SecondAlgorithm) + " conclusion" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
    co_return StatusCode::SUCCESS;
 }
 

--- a/components/simple/SecondAlgorithm.cpp
+++ b/components/simple/SecondAlgorithm.cpp
@@ -10,45 +10,59 @@
 #include "../../tests/NVTXUtils.hpp"
 using WP17Scheduler::NVTXUtils::nvtxcolor;
 
+SecondAlgorithm::SecondAlgorithm(bool verbose)
+    : m_verbose(verbose) {}
 
 StatusCode SecondAlgorithm::initialize() {
-   nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(SecondAlgorithm)};
-   SC_CHECK(AlgorithmBase::addDependency<int>("Object1"));
-   SC_CHECK(AlgorithmBase::addProduct<int>("Object3"));
-   std::cout << MEMBER_FUNCTION_NAME(SecondAlgorithm) << std::endl;
-   return StatusCode::SUCCESS;
+    nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(SecondAlgorithm)};
+    SC_CHECK(AlgorithmBase::addDependency<int>("Object1"));
+    SC_CHECK(AlgorithmBase::addProduct<int>("Object3"));
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(SecondAlgorithm) << std::endl;
+    }
+    return StatusCode::SUCCESS;
 }
-
 
 AlgorithmBase::AlgCoInterface SecondAlgorithm::execute(EventContext ctx) const {
-   nvtx3::unique_range range{MEMBER_FUNCTION_NAME(SecondAlgorithm) + " part1" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
-   const int* input = nullptr;
-   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).retrieve(input, AlgorithmBase::dependencies()[0]));
-   auto output = std::make_unique<int>(-1);
-   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output), AlgorithmBase::products()[0]));
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(SecondAlgorithm) + " part1 start, " << ctx.info() << std::endl;
+    }
+    nvtx3::unique_range range{MEMBER_FUNCTION_NAME(SecondAlgorithm) + " part1" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
+    const int* input = nullptr;
+    SC_CHECK_YIELD(EventStoreRegistry::of(ctx).retrieve(input, AlgorithmBase::dependencies()[0]));
+    auto output = std::make_unique<int>(-1);
+    SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output), AlgorithmBase::products()[0]));
 
-   std::cout << MEMBER_FUNCTION_NAME(SecondAlgorithm) + " part1, " << ctx.info() << std::endl;
-   ctx.scheduler->setCudaSlotState(ctx.slotNumber, 1, false);
-   launchTestKernel3(ctx.stream);
-   cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 1});
-   { auto r = std::move(range); } // End range
-   co_yield StatusCode::SUCCESS;
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(SecondAlgorithm) + " part1, " << ctx.info() << std::endl;
+    }
+    ctx.scheduler->setCudaSlotState(ctx.slotNumber, 1, false);
+    launchTestKernel3(ctx.stream);
+    cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 1});
+    { auto r = std::move(range); } // End range
+    co_yield StatusCode::SUCCESS;
 
-   nvtx3::unique_range range2{MEMBER_FUNCTION_NAME(SecondAlgorithm) + " part2" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
-   std::cout << MEMBER_FUNCTION_NAME(SecondAlgorithm) + " part2, " << ctx.info() << std::endl;
-   ctx.scheduler->setCudaSlotState(ctx.slotNumber, 1, false);
-   launchTestKernel4(ctx.stream);
-   cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 1});
-   // Suspend the coroutine until the kernel is finished.
-   { auto r2 = std::move(range2); } // End range
-   co_yield StatusCode::SUCCESS;
-   auto range3 = nvtx3::scoped_range{MEMBER_FUNCTION_NAME(SecondAlgorithm) + " conclusion" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
-   co_return StatusCode::SUCCESS;
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(SecondAlgorithm) + " part2 start, " << ctx.info() << std::endl;
+    }
+    nvtx3::unique_range range2{MEMBER_FUNCTION_NAME(SecondAlgorithm) + " part2" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
+    ctx.scheduler->setCudaSlotState(ctx.slotNumber, 1, false);
+    launchTestKernel4(ctx.stream);
+    cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 1});
+    { auto r2 = std::move(range2); } // End range
+    co_yield StatusCode::SUCCESS;
+
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(SecondAlgorithm) + " conclusion, " << ctx.info() << std::endl;
+    }
+    auto range3 = nvtx3::scoped_range{MEMBER_FUNCTION_NAME(SecondAlgorithm) + " conclusion" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
+    co_return StatusCode::SUCCESS;
 }
 
-
 StatusCode SecondAlgorithm::finalize() {
-   nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(SecondAlgorithm)};
-   std::cout << MEMBER_FUNCTION_NAME(SecondAlgorithm) << std::endl;
-   return StatusCode::SUCCESS;
+    nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(SecondAlgorithm)};
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(SecondAlgorithm) << std::endl;
+    }
+    return StatusCode::SUCCESS;
 }

--- a/components/simple/SecondAlgorithm.cpp
+++ b/components/simple/SecondAlgorithm.cpp
@@ -21,7 +21,7 @@ StatusCode SecondAlgorithm::initialize() {
 
 
 AlgorithmBase::AlgCoInterface SecondAlgorithm::execute(EventContext ctx) const {
-   nvtx3::unique_range range{MEMBER_FUNCTION_NAME(SecondAlgorithm) + " (1)", nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
+   nvtx3::unique_range range{MEMBER_FUNCTION_NAME(SecondAlgorithm) + " part1" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
    const int* input = nullptr;
    SC_CHECK_YIELD(EventStoreRegistry::of(ctx).retrieve(input, AlgorithmBase::dependencies()[0]));
    auto output = std::make_unique<int>(-1);
@@ -34,7 +34,7 @@ AlgorithmBase::AlgCoInterface SecondAlgorithm::execute(EventContext ctx) const {
    { auto r = std::move(range); } // End range
    co_yield StatusCode::SUCCESS;
 
-   nvtx3::unique_range range2{MEMBER_FUNCTION_NAME(SecondAlgorithm) + " (2)", nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
+   nvtx3::unique_range range2{MEMBER_FUNCTION_NAME(SecondAlgorithm) + " part2" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
    std::cout << MEMBER_FUNCTION_NAME(SecondAlgorithm) + " part2, " << ctx.info() << std::endl;
    ctx.scheduler->setCudaSlotState(ctx.slotNumber, 1, false);
    launchTestKernel4(ctx.stream);

--- a/components/simple/SecondAlgorithm.hpp
+++ b/components/simple/SecondAlgorithm.hpp
@@ -1,12 +1,16 @@
 #pragma once
 
-
 #include "AlgorithmBase.hpp"
-
 
 class SecondAlgorithm : public AlgorithmBase {
 public:
-   StatusCode initialize() override;
-   AlgCoInterface execute(EventContext ctx) const override;
-   StatusCode finalize() override;
+    // Constructor with verbose parameter
+    explicit SecondAlgorithm(bool verbose = false);
+
+    StatusCode initialize() override;
+    AlgCoInterface execute(EventContext ctx) const override;
+    StatusCode finalize() override;
+
+private:
+    bool m_verbose; // Whether verbose output is enabled
 };

--- a/components/simple/SecondAlgorithm.hpp
+++ b/components/simple/SecondAlgorithm.hpp
@@ -6,7 +6,7 @@
 
 class SecondAlgorithm : public AlgorithmBase {
 public:
-   virtual StatusCode initialize() override;
-   virtual AlgCoInterface execute(EventContext ctx) const override;
-   virtual StatusCode finalize() override;
+   StatusCode initialize() override;
+   AlgCoInterface execute(EventContext ctx) const override;
+   StatusCode finalize() override;
 };

--- a/components/simple/ThirdAlgorithm.cpp
+++ b/components/simple/ThirdAlgorithm.cpp
@@ -19,9 +19,9 @@ StatusCode ThirdAlgorithm::initialize() {
 
 AlgorithmBase::AlgCoInterface ThirdAlgorithm::execute(EventContext ctx) const {
    const int* input = nullptr;
-   SC_CHECK_YIELD(eventStoreOf(ctx).retrieve(input, AlgorithmBase::dependencies()[0]));
+   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).retrieve(input, AlgorithmBase::dependencies()[0]));
    auto output = std::make_unique<int>(-1);
-   SC_CHECK_YIELD(eventStoreOf(ctx).record(std::move(output), AlgorithmBase::products()[0]));
+   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output), AlgorithmBase::products()[0]));
 
    std::cout << MEMBER_FUNCTION_NAME(ThirdAlgorithm) + " part1, " << ctx.info() << std::endl;
    ctx.scheduler->setCudaSlotState(ctx.slotNumber, 2, false);

--- a/components/simple/ThirdAlgorithm.cpp
+++ b/components/simple/ThirdAlgorithm.cpp
@@ -21,7 +21,7 @@ StatusCode ThirdAlgorithm::initialize() {
 
 
 AlgorithmBase::AlgCoInterface ThirdAlgorithm::execute(EventContext ctx) const {
-   nvtx3::unique_range range{MEMBER_FUNCTION_NAME(ThirdAlgorithm) + " (1)", nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
+   nvtx3::unique_range range{MEMBER_FUNCTION_NAME(ThirdAlgorithm) + " part1" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
    const int* input = nullptr;
    SC_CHECK_YIELD(EventStoreRegistry::of(ctx).retrieve(input, AlgorithmBase::dependencies()[0]));
    auto output = std::make_unique<int>(-1);

--- a/components/simple/ThirdAlgorithm.cpp
+++ b/components/simple/ThirdAlgorithm.cpp
@@ -10,36 +10,49 @@
 #include "../../tests/NVTXUtils.hpp"
 using WP17Scheduler::NVTXUtils::nvtxcolor;
 
+ThirdAlgorithm::ThirdAlgorithm(bool verbose)
+    : m_verbose(verbose) {}
 
 StatusCode ThirdAlgorithm::initialize() {
-   nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(ThirdAlgorithm)};
-   SC_CHECK(AlgorithmBase::addDependency<int>("Object2"));
-   SC_CHECK(AlgorithmBase::addProduct<int>("Object4"));
-   std::cout << MEMBER_FUNCTION_NAME(ThirdAlgorithm) << std::endl;
-   return StatusCode::SUCCESS;
+    nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(ThirdAlgorithm)};
+    SC_CHECK(AlgorithmBase::addDependency<int>("Object2"));
+    SC_CHECK(AlgorithmBase::addProduct<int>("Object4"));
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(ThirdAlgorithm) << std::endl;
+    }
+    return StatusCode::SUCCESS;
 }
-
 
 AlgorithmBase::AlgCoInterface ThirdAlgorithm::execute(EventContext ctx) const {
-   nvtx3::unique_range range{MEMBER_FUNCTION_NAME(ThirdAlgorithm) + " part1" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
-   const int* input = nullptr;
-   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).retrieve(input, AlgorithmBase::dependencies()[0]));
-   auto output = std::make_unique<int>(-1);
-   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output), AlgorithmBase::products()[0]));
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(ThirdAlgorithm) + " part1 start, " << ctx.info() << std::endl;
+    }
+    nvtx3::unique_range range{MEMBER_FUNCTION_NAME(ThirdAlgorithm) + " part1" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
+    const int* input = nullptr;
+    SC_CHECK_YIELD(EventStoreRegistry::of(ctx).retrieve(input, AlgorithmBase::dependencies()[0]));
+    auto output = std::make_unique<int>(-1);
+    SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(output), AlgorithmBase::products()[0]));
 
-   std::cout << MEMBER_FUNCTION_NAME(ThirdAlgorithm) + " part1, " << ctx.info() << std::endl;
-   ctx.scheduler->setCudaSlotState(ctx.slotNumber, 2, false);
-   launchTestKernel5(ctx.stream);
-   cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 2});
-   { auto r = std::move(range); } // End range
-   co_yield StatusCode::SUCCESS;
-   auto range2 = nvtx3::scoped_range{MEMBER_FUNCTION_NAME(ThirdAlgorithm) + " conclusion" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
-   co_return StatusCode::SUCCESS;
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(ThirdAlgorithm) + " part1, " << ctx.info() << std::endl;
+    }
+    ctx.scheduler->setCudaSlotState(ctx.slotNumber, 2, false);
+    launchTestKernel5(ctx.stream);
+    cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 2});
+    { auto r = std::move(range); } // End range
+    co_yield StatusCode::SUCCESS;
+
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(ThirdAlgorithm) + " conclusion, " << ctx.info() << std::endl;
+    }
+    auto range2 = nvtx3::scoped_range{MEMBER_FUNCTION_NAME(ThirdAlgorithm) + " conclusion" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
+    co_return StatusCode::SUCCESS;
 }
 
-
 StatusCode ThirdAlgorithm::finalize() {
-   nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(ThirdAlgorithm)};
-   std::cout << MEMBER_FUNCTION_NAME(ThirdAlgorithm) << std::endl;
-   return StatusCode::SUCCESS;
+    nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(ThirdAlgorithm)};
+    if (m_verbose) {
+        std::cout << MEMBER_FUNCTION_NAME(ThirdAlgorithm) << std::endl;
+    }
+    return StatusCode::SUCCESS;
 }

--- a/components/simple/ThirdAlgorithm.cpp
+++ b/components/simple/ThirdAlgorithm.cpp
@@ -7,9 +7,12 @@
 #include "EventStore.hpp"
 #include "MemberFunctionName.hpp"
 #include "Scheduler.hpp"
+#include "../../tests/NVTXUtils.hpp"
+using WP17Scheduler::NVTXUtils::nvtxcolor;
 
 
 StatusCode ThirdAlgorithm::initialize() {
+   nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(ThirdAlgorithm)};
    SC_CHECK(AlgorithmBase::addDependency<int>("Object2"));
    SC_CHECK(AlgorithmBase::addProduct<int>("Object4"));
    std::cout << MEMBER_FUNCTION_NAME(ThirdAlgorithm) << std::endl;
@@ -18,6 +21,7 @@ StatusCode ThirdAlgorithm::initialize() {
 
 
 AlgorithmBase::AlgCoInterface ThirdAlgorithm::execute(EventContext ctx) const {
+   nvtx3::unique_range range{MEMBER_FUNCTION_NAME(ThirdAlgorithm) + " (1)", nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
    const int* input = nullptr;
    SC_CHECK_YIELD(EventStoreRegistry::of(ctx).retrieve(input, AlgorithmBase::dependencies()[0]));
    auto output = std::make_unique<int>(-1);
@@ -33,6 +37,7 @@ AlgorithmBase::AlgCoInterface ThirdAlgorithm::execute(EventContext ctx) const {
 
 
 StatusCode ThirdAlgorithm::finalize() {
+   nvtx3::scoped_range range{MEMBER_FUNCTION_NAME(ThirdAlgorithm)};
    std::cout << MEMBER_FUNCTION_NAME(ThirdAlgorithm) << std::endl;
    return StatusCode::SUCCESS;
 }

--- a/components/simple/ThirdAlgorithm.cpp
+++ b/components/simple/ThirdAlgorithm.cpp
@@ -31,7 +31,9 @@ AlgorithmBase::AlgCoInterface ThirdAlgorithm::execute(EventContext ctx) const {
    ctx.scheduler->setCudaSlotState(ctx.slotNumber, 2, false);
    launchTestKernel5(ctx.stream);
    cudaLaunchHostFunc(ctx.stream, notifyScheduler, new Notification{ctx, 2});
-   cudaStreamSynchronize(ctx.stream);
+   { auto r = std::move(range); } // End range
+   co_yield StatusCode::SUCCESS;
+   auto range2 = nvtx3::scoped_range{MEMBER_FUNCTION_NAME(ThirdAlgorithm) + " conclusion" + ctx.info(), nvtxcolor(ctx.eventNumber), nvtx3::payload{ctx.eventNumber}};
    co_return StatusCode::SUCCESS;
 }
 

--- a/components/simple/ThirdAlgorithm.hpp
+++ b/components/simple/ThirdAlgorithm.hpp
@@ -1,12 +1,16 @@
 #pragma once
 
-
 #include "AlgorithmBase.hpp"
-
 
 class ThirdAlgorithm : public AlgorithmBase {
 public:
-   StatusCode initialize() override;
-   AlgCoInterface execute(EventContext ctx) const override;
-   StatusCode finalize() override;
+    // Constructor with verbose parameter
+    explicit ThirdAlgorithm(bool verbose = false);
+
+    StatusCode initialize() override;
+    AlgCoInterface execute(EventContext ctx) const override;
+    StatusCode finalize() override;
+
+private:
+    bool m_verbose; // Whether verbose output is enabled
 };

--- a/components/simple/ThirdAlgorithm.hpp
+++ b/components/simple/ThirdAlgorithm.hpp
@@ -6,7 +6,7 @@
 
 class ThirdAlgorithm : public AlgorithmBase {
 public:
-   virtual StatusCode initialize() override;
-   virtual AlgCoInterface execute(EventContext ctx) const override;
-   virtual StatusCode finalize() override;
+   StatusCode initialize() override;
+   AlgCoInterface execute(EventContext ctx) const override;
+   StatusCode finalize() override;
 };

--- a/components/traccc/TracccAlgs.cpp
+++ b/components/traccc/TracccAlgs.cpp
@@ -47,10 +47,10 @@ StatusCode TracccCellsAlgorithm::initialize() {
 
 AlgorithmBase::AlgCoInterface TracccCellsAlgorithm::execute(EventContext ctx) const {
    SC_CHECK_YIELD(
-       eventStoreOf(ctx).record(std::move(m_detector), AlgorithmBase::products()[0]));
+       EventStoreRegistry::of(ctx).record(std::move(m_detector), AlgorithmBase::products()[0]));
    SC_CHECK_YIELD(
-       eventStoreOf(ctx).record(std::move(m_det_descr), AlgorithmBase::products()[1]));
-   SC_CHECK_YIELD(eventStoreOf(ctx).record(std::move(m_cells), AlgorithmBase::products()[2]));
+    EventStoreRegistry::of(ctx).record(std::move(m_det_descr), AlgorithmBase::products()[1]));
+   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).record(std::move(m_cells), AlgorithmBase::products()[2]));
 
    std::cout << MEMBER_FUNCTION_NAME(TracccCellsAlgorithm) << std::endl;
    co_return StatusCode::SUCCESS;
@@ -80,13 +80,13 @@ StatusCode TracccComputeAlgorithm::initialize() {
 
 AlgorithmBase::AlgCoInterface TracccComputeAlgorithm::execute(EventContext ctx) const {
    const traccc::default_detector::host* detector_dep = nullptr;
-   SC_CHECK_YIELD(eventStoreOf(ctx).retrieve(detector_dep, AlgorithmBase::dependencies()[0]));
+   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).retrieve(detector_dep, AlgorithmBase::dependencies()[0]));
 
    const traccc::silicon_detector_description::host* det_descr_dep = nullptr;
-   SC_CHECK_YIELD(eventStoreOf(ctx).retrieve(det_descr_dep, AlgorithmBase::dependencies()[1]));
+   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).retrieve(det_descr_dep, AlgorithmBase::dependencies()[1]));
 
    const std::vector<traccc::edm::silicon_cell_collection::host>* cells_dep = nullptr;
-   SC_CHECK_YIELD(eventStoreOf(ctx).retrieve(cells_dep, AlgorithmBase::dependencies()[2]));
+   SC_CHECK_YIELD(EventStoreRegistry::of(ctx).retrieve(cells_dep, AlgorithmBase::dependencies()[2]));
 
    const auto& cells = (*cells_dep)[ctx.eventNumber % m_numEvents];
    std::cout << "Event number: " << ctx.eventNumber << std::endl;

--- a/externals/traccc/CMakeLists.txt
+++ b/externals/traccc/CMakeLists.txt
@@ -14,11 +14,11 @@ mark_as_advanced( SCHED_TRACCC_SOURCE )
 FetchContent_Declare( traccc ${SCHED_TRACCC_SOURCE} OVERRIDE_FIND_PACKAGE )
 
 # Options used in the build of traccc.
-set( TRACCC_BUILD_TESTING FALSE CACHE BOOL
+set( TRACCC_BUILD_TESTING TRUE CACHE BOOL
    "Turn off the build of the traccc unit tests" )
-set( TRACCC_BUILD_BENCHMARKS FALSE CACHE BOOL
+set( TRACCC_BUILD_BENCHMARKS TRUE CACHE BOOL
    "Turn off the build of the traccc benchmarks" )
-set( TRACCC_BUILD_EXAMPLES FALSE CACHE BOOL
+set( TRACCC_BUILD_EXAMPLES TRUE CACHE BOOL
    "Turn off the build of the traccc examples" )
 set( TRACCC_USE_ROOT FALSE CACHE BOOL
    "Don't use ROOT as part of the traccc build" )

--- a/src/AlgExecState.hpp
+++ b/src/AlgExecState.hpp
@@ -5,7 +5,9 @@
 
 #include "StatusCode.hpp"
 
-
+/**
+ * @brief Wrapper fpr algorithms states. With stream operator and reset to default state (UNSCHEDULED).
+ */
 class AlgExecState {
 public:
    enum class State { UNSCHEDULED, SCHEDULED, SUSPENDED, FINISHED, ERROR };
@@ -33,10 +35,17 @@ public:
       return m_state;
    }
 
+   /**
+    * @brief conversts to `StatusCode` based on the current state.
+    * @return SUCCESS or FAILURE
+    */
    StatusCode getStatus() const {
       return m_state == ERROR ? StatusCode::FAILURE : StatusCode::SUCCESS;
    }
 
+   /**
+    * @brief Resets the state to UNSCHEDULED.
+    */
    void reset() {
       new(this)AlgExecState;
    }

--- a/src/AlgExecState.hpp
+++ b/src/AlgExecState.hpp
@@ -38,7 +38,7 @@ public:
    }
 
    void reset() {
-      *this = AlgExecState{};
+      new(this)AlgExecState;
    }
 
    friend bool operator==(const AlgExecState& state1, const AlgExecState& state2) {

--- a/src/AlgorithmBase.hpp
+++ b/src/AlgorithmBase.hpp
@@ -14,7 +14,9 @@
 // Forward declarations.
 struct EventContext;
 
-
+/**
+ * @brief Base class for algorithms. Algorithms express dependencies on products
+ */
 class AlgorithmBase {
 public:
    using AlgCoInterface = CoInterface<Promise<StatusCode, StatusCode>>;

--- a/src/EventContentManager.cpp
+++ b/src/EventContentManager.cpp
@@ -10,6 +10,13 @@
 
 
 namespace {
+/**
+ * @brief Helper function setting the bits in the bitset corresponding to the objects (names), with a mapping of
+ * name to index based on the position of the string in allObjectsVec.
+ * @param allObjectsVec vector of string mapping string position to bit position (reset at startup).
+ * @param objects list of string to be added to the bitset
+ * @param objBitset the bitset.
+ */
 void setBits(const std::vector<std::string>& allObjectsVec,
              const std::vector<std::string>& objects, boost::dynamic_bitset<>& objBitset) {
    objBitset.reset();

--- a/src/EventContentManager.hpp
+++ b/src/EventContentManager.hpp
@@ -12,30 +12,65 @@
 class AlgorithmBase;
 class StatusCode;
 
-
+/**
+ * @brief Scheduler slot level manager for the content of the event. It manages the dependencies and statuses of the algorithms,
+ * as well as an array of references to the algorithms themselves.
+ * The algorithms dependencies and products are stored as bitsets. The results of an algorithm is recorded in an all-or-nothing manner,
+ * at the full completion of the algorithm execution.
+ * @see `setBits()` in `EventContentManager.cpp`.
+ */
 class EventContentManager {
 public:
+   /**
+    * @brief Default constructor, only used at initialization of the scheduler slot.
+    */
    EventContentManager() = default;
 
+
+   /**
+    * @brief Constructs the EventContentManager with a list of algorithms.
+    * It initializes the dependencies and products bitsets for each algorithm. The string to bitset mapping
+    * only exists during the execution of the algorithm.
+    * @param algs A vector of references to AlgorithmBase objects.
+    */
    explicit EventContentManager(
        const std::vector<std::reference_wrapper<AlgorithmBase>>& algs);
    EventContentManager(const EventContentManager& E);
    EventContentManager& operator=(const EventContentManager& E);
 
-   // Set one of the algorithms as having finished its execution.
+   /**
+    * @brief Set one of the algorithms as having finished its execution.
+    * All the products that the algorithm
+    * @note Thread safe 
+    */
    StatusCode setAlgExecuted(std::size_t alg);
 
    // Check if an algorithm is ready to be run.
+   /**
+    * @brief Check if an algorithm's data dependencies are availble.
+    * @note Thread safe
+    */
    bool isAlgExecutable(std::size_t alg) const;
 
    // Reset the event store content.
+   /**
+    * @brief Reset the event store content.s
+    */
    void reset();
 
 private:
+   /// Type used for bitset.
    typedef boost::dynamic_bitset<> DataObjColl_t;
 
+   /// Per-algorithm dependencies
    std::vector<DataObjColl_t> m_algDependencies;
+
+   /// Per-algorithm products
    std::vector<DataObjColl_t> m_algProducts;
+
+   /// Current content of the event store.
    DataObjColl_t m_algContent;
+
+   /// Mutex: this object is not thread-safe.
    mutable std::mutex m_storeContentMutex;
 };

--- a/src/EventContentManager.hpp
+++ b/src/EventContentManager.hpp
@@ -49,6 +49,7 @@ public:
    /**
     * @brief Check if an algorithm's data dependencies are availble.
     * @note Thread safe
+    * @todo Could be renamed to `areAlgoDependenciesMet()`.
     */
    bool isAlgExecutable(std::size_t alg) const;
 

--- a/src/EventContext.cpp
+++ b/src/EventContext.cpp
@@ -4,11 +4,9 @@
 
 
 void notifyScheduler(void* args) {
-   Notification* notify = static_cast<Notification*>(args);
+   std::unique_ptr<Notification> notify(static_cast<Notification*>(args));
    EventContext& ctx = notify->ctx;
 
    ctx.scheduler->setCudaSlotState(ctx.slotNumber, notify->algNumber, true);
    ctx.scheduler->actionUpdate();
-
-   delete notify;
 }

--- a/src/EventContext.hpp
+++ b/src/EventContext.hpp
@@ -10,7 +10,10 @@
 // Forward declarations.
 class Scheduler;
 
-
+/**
+ * @brief Indices to event/slot context, plus pointed to global scheduler, they are the sole interface to the algorithms, via `execute()`.
+ * Also contains the CUDA stream.
+ */
 struct EventContext {
    int eventNumber = 0;
    int slotNumber = 0;
@@ -23,7 +26,9 @@ struct EventContext {
    }
 };
 
-
+/**
+ * @brief Parameters passed to the CUDA callback function.
+ */
 struct Notification {
    EventContext& ctx;
    std::size_t algNumber;

--- a/src/EventStore.hpp
+++ b/src/EventStore.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-
 #include <cassert>
 #include <map>
 #include <memory>
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <typeinfo>
 #include <utility>
@@ -47,13 +48,63 @@ private:
 };
 
 /**
+ * @brief Struct to hold the value and its associated mutex.
+ */
+struct ValueWithMutex {
+   std::unique_ptr<ObjectHolderBase> value;
+   mutable std::shared_mutex mutex;
+
+   // Default constructor
+   ValueWithMutex() = default;
+
+   // Move constructor
+   ValueWithMutex(ValueWithMutex&& other) noexcept
+       : value(std::move(other.value)) {
+       // Note: `mutex` is default-constructed for the new object
+   }
+
+   // Move assignment operator
+   ValueWithMutex& operator=(ValueWithMutex&& other) noexcept {
+       if (this != &other) {
+           value = std::move(other.value);
+           // Note: `mutex` is not moved; it remains default-constructed
+       }
+       return *this;
+   }
+
+   // Deleted copy constructor and copy assignment operator
+   ValueWithMutex(const ValueWithMutex&) = delete;
+   ValueWithMutex& operator=(const ValueWithMutex&) = delete;
+};
+
+/**
  * @brief Store for event data, allowing to record and retrieve objects by name. Objects can be any type. Type is also checked at retrieval time.
- * @note This class is not thread-safe.
- * @note The obecjt is returned by pointer.
- * @todo Get rid of pointer interface.
  */
 class EventStore {
 public:
+   using KeyType = std::string;
+   using ValueType = ValueWithMutex;
+
+   // Trivial constructor
+   EventStore() = default;
+
+   // Move constructor
+   EventStore(EventStore&& other) noexcept {
+      std::unique_lock<std::shared_mutex> lock(other.m_globalMutex); // Lock the source's global mutex
+      m_store = std::move(other.m_store);
+   }
+
+   // Move assignment operator
+   EventStore& operator=(EventStore&& other) noexcept {
+      if (this != &other) {
+         std::unique_lock<std::shared_mutex> lockThis(m_globalMutex, std::defer_lock);
+         std::unique_lock<std::shared_mutex> lockOther(other.m_globalMutex, std::defer_lock);
+         std::lock(lockThis, lockOther); // Lock both mutexes
+         m_store = std::move(other.m_store);
+      }
+      return *this;
+   }
+
    /**
     * @brief Test product presence in the store.
     * @tparam T product type
@@ -62,24 +113,32 @@ public:
     */
    template <typename T>
    bool contains(const std::string& name) const {
-      auto it = m_dataStore.find(name);
-      return (it != m_dataStore.end()) && (typeid(T) == it->second->get_type());
+      auto it = m_store.find(name);
+      if (it == m_store.end()) {
+         return false;
+      }
+      std::shared_lock<std::shared_mutex> lock(it->second.mutex); // Lock the element mutex
+      return typeid(T) == it->second.value->get_type();
    }
 
    /**
     * @brief Get product
     * @tparam T product type
-    * @param obj reference to pointer, ill be set to point to the product
+    * @param obj reference to pointer, will be set to point to the product
     * @param name Name of the product
     * @return StatusCode (FAILURE if the product is not present or of the wrong type)
     */
    template <typename T>
    StatusCode retrieve(const T*& obj, const std::string& name) {
-      if(!this->contains<T>(name)) {
+      auto it = m_store.find(name);
+      if (it == m_store.end()) {
          return StatusCode::FAILURE;
       }
-
-      obj = static_cast<const T*>(m_dataStore[name]->get_pointer());
+      std::shared_lock<std::shared_mutex> lock(it->second.mutex); // Lock the element mutex
+      if (typeid(T) != it->second.value->get_type()) {
+         return StatusCode::FAILURE;
+      }
+      obj = static_cast<const T*>(it->second.value->get_pointer());
       return StatusCode::SUCCESS;
    }
 
@@ -93,11 +152,15 @@ public:
    template <typename T>
    StatusCode record(std::unique_ptr<T>&& obj, const std::string& name) {
       // Cannot record multiple objects with the same name.
-      if(m_dataStore.find(name) != m_dataStore.end()) {
+      auto it = m_store.find(name);
+      if (it != m_store.end()) {
          return StatusCode::FAILURE;
       }
 
-      m_dataStore[name] = std::make_unique<ObjectHolder<T>>(std::move(obj));
+      ValueWithMutex newValue;
+      newValue.value = std::make_unique<ObjectHolder<T>>(std::move(obj));
+      std::unique_lock<std::shared_mutex> lock(m_globalMutex); // Lock the global mutex for write
+      m_store[name] = std::move(newValue);
       return StatusCode::SUCCESS;
    }
 
@@ -105,12 +168,13 @@ public:
     * @brief Clears the store and deletes all the products.
     */
    void clear() {
-      m_dataStore.clear();
+      std::unique_lock<std::shared_mutex> lock(m_globalMutex); // Lock the global mutex for write
+      m_store.clear();
    }
 
 private:
-   /// Map to hold the products by name.
-   std::map<std::string, std::unique_ptr<ObjectHolderBase>> m_dataStore;
+   mutable std::shared_mutex m_globalMutex; // Global lock for the map
+   std::map<KeyType, ValueType> m_store;    // The map storing the elements with their associated mutexes
 };
 
 /**

--- a/src/EventStore.hpp
+++ b/src/EventStore.hpp
@@ -12,7 +12,9 @@
 #include "EventContext.hpp"
 #include "StatusCode.hpp"
 
-
+/**
+ * @brief And `std::any`-style container for unique pointer (abstract base class).
+ */
 struct ObjectHolderBase {
    ObjectHolderBase() = default;
    virtual ~ObjectHolderBase() = default;
@@ -21,7 +23,10 @@ struct ObjectHolderBase {
    virtual const std::type_info& get_type() const = 0;
 };
 
-
+/**
+ * @brief Concrete implementation of `ObjectHolderBase` for object type `T`.
+ * @tparam `T` the type of the object pointers to hold.
+ */
 template <typename T>
 class ObjectHolder : public ObjectHolderBase {
 public:
@@ -41,15 +46,33 @@ private:
    std::unique_ptr<T> m_ptr;
 };
 
-
+/**
+ * @brief Store for event data, allowing to record and retrieve objects by name. Objects can be any type. Type is also checked at retrieval time.
+ * @note This class is not thread-safe.
+ * @note The obecjt is returned by pointer.
+ * @todo Get rid of pointer interface.
+ */
 class EventStore {
 public:
+   /**
+    * @brief Test product presence in the store.
+    * @tparam T product type
+    * @param name Name of the product
+    * @return boolean, whether the product of the right type is present.
+    */
    template <typename T>
    bool contains(const std::string& name) const {
       auto it = m_dataStore.find(name);
       return (it != m_dataStore.end()) && (typeid(T) == it->second->get_type());
    }
 
+   /**
+    * @brief Get product
+    * @tparam T product type
+    * @param obj reference to pointer, ill be set to point to the product
+    * @param name Name of the product
+    * @return StatusCode (FAILURE if the product is not present or of the wrong type)
+    */
    template <typename T>
    StatusCode retrieve(const T*& obj, const std::string& name) {
       if(!this->contains<T>(name)) {
@@ -60,6 +83,13 @@ public:
       return StatusCode::SUCCESS;
    }
 
+   /**
+    * @brief Record a product in the store.
+    * @tparam T product type
+    * @param obj Unique pointer to the product to be recorded. Ownership is transferred to the store.
+    * @param name Name of the product.
+    * @return StatusCode (FAILURE if the product with the same name is already present)
+    */
    template <typename T>
    StatusCode record(std::unique_ptr<T>&& obj, const std::string& name) {
       // Cannot record multiple objects with the same name.
@@ -71,40 +101,46 @@ public:
       return StatusCode::SUCCESS;
    }
 
+   /**
+    * @brief Clears the store and deletes all the products.
+    */
    void clear() {
       m_dataStore.clear();
    }
 
 private:
+   /// Map to hold the products by name.
    std::map<std::string, std::unique_ptr<ObjectHolderBase>> m_dataStore;
 };
 
-
+/**
+ * @brief Singleton registry for event stores, indexed by slot number.
+ * Initialized in Scheduler::initialize(). Then referenced by `eventStoreOf()` function.
+ */
 class EventStoreRegistry {
+// Private first to allow static functions to access it.
+private:
+   EventStoreRegistry() = default;
+
+   /// Singleton instance handler
+   static std::vector<EventStore>& gInstance() {
+      static std::vector<EventStore> eventStores;
+      return eventStores;
+   }
 public:
    EventStoreRegistry(const EventStoreRegistry&) = delete;
    EventStoreRegistry& operator=(const EventStoreRegistry&) = delete;
 
-   static EventStoreRegistry& instance() {
-      static EventStoreRegistry r;
-      return r;
+   /**
+    * @brief Singleton accessor and instance creator/holder.
+    * @return reference to the singleton instance of EventStoreRegistry.
+    */
+   static EventStore& of(const EventContext& ctx) {
+      return gInstance().at(ctx.slotNumber);
    }
 
-   auto& data() {
-      return eventStores;
+   static void initialize(std::size_t slots) {
+      gInstance().resize(slots);
    }
-
-   const auto& data() const {
-      return eventStores;
-   }
-
-private:
-   EventStoreRegistry() = default;
-
-   std::vector<EventStore> eventStores;
+   
 };
-
-
-inline EventStore& eventStoreOf(const EventContext& ctx) {
-   return EventStoreRegistry::instance().data().at(ctx.slotNumber);
-}

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -20,6 +20,7 @@ Scheduler::Scheduler(int events, int threads, int slots)
       m_remainingEvents{},
       m_arena{threads, 0} {
    // Set up a global limit on the number of threads.
+   // TODO: explain why + 1
    tbb::global_control global_thread_limit(tbb::global_control::max_allowed_parallelism,
                                            m_threads + 1);
    EventStoreRegistry::instance().data().resize(slots);
@@ -205,7 +206,7 @@ void Scheduler::pushAction(int slot, std::size_t ialg, SlotState& slotState) {
          }
 
          slotState.algStatuses[ialg] = algStatus;
-         if(algStatus.isFailure()) {
+         if(!algStatus) {
             slotState.algStates[ialg] = AlgExecState::ERROR;
             this->m_actions.push([algStatus]() -> StatusCode { return algStatus; });
          } else {

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -189,7 +189,8 @@ void Scheduler::pushAction(int slot, std::size_t ialg, SlotState& slotState) {
    slotState.algExecStates[ialg] = AlgExecState::SCHEDULED;
 
    // Add the action that would schedule the execution of the algorithm.
-   // TODO: Why both Arena.execurte (which is semantically synchronous) and Group.run?
+   // m_arena.execute() is used to ensure that the action is executed (synchronously) in our task arena.
+   // next, m_group.run() launches the asynchronous task in the group to be able to `wait()`.
    m_arena.execute([this, ialg, slot, &slotState, &alg = m_algorithms[ialg].get()]() {
       m_group.run([this, ialg, slot, &slotState, &alg]() {
          if(slotState.coroutines[ialg].empty()) {
@@ -239,8 +240,8 @@ void Scheduler::printStatuses() const {
    std::cout << std::endl;
    std::cout << std::endl;
    std::cout << "Printing all statuses" << std::endl;
-   for(std::size_t i{}; const auto& slotState : m_slotStates) {
-      for(std::size_t j{}; const auto& algStatus : slotState.algStatuses) {
+   for(std::size_t i{0}; const auto& slotState : m_slotStates) {
+      for(std::size_t j{0}; const auto& algStatus : slotState.algStatuses) {
          std::cout << "slot: " << i << ", algorithm number: " << j++ << "\n"
                    << algStatus.what() << std::endl
                    << std::endl;

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -23,7 +23,7 @@ Scheduler::Scheduler(int events, int threads, int slots)
    // TODO: explain why + 1
    tbb::global_control global_thread_limit(tbb::global_control::max_allowed_parallelism,
                                            m_threads + 1);
-   EventStoreRegistry::instance().data().resize(slots);
+   EventStoreRegistry::initialize(slots);
 }
 
 
@@ -138,7 +138,7 @@ StatusCode Scheduler::update() {
       if(std::ranges::all_of(slotState.algExecStates,
                              [](AlgExecState x) { return x == AlgExecState::FINISHED; })) {
          EventContext ctx{slotState.eventNumber, slot, this, m_streams[slot]};
-         eventStoreOf(ctx).clear();
+         EventStoreRegistry::of(ctx).clear();
          slotState.eventNumber = m_nextEvent++;
          // vector<bool> not compatible with std::ranges.
          std::fill(slotState.cudaFinished.begin(), slotState.cudaFinished.end(), true);

--- a/src/Scheduler.hpp
+++ b/src/Scheduler.hpp
@@ -17,53 +17,162 @@
 #include "EventContentManager.hpp"
 #include "StatusCode.hpp"
 
+namespace WP17Scheduler {
+   /**
+    * @brief Base exception class
+    */
+   class Exception: public std::exception {
+   public:
+      Exception(const std::string &w): m_what(w) {}
+      const char * what() const noexcept override { return m_what.c_str(); } 
+   private:
+      const std::string m_what;
+   };
+}
 
+#define DEFINE_EXCEPTION(name) class name: public WP17Scheduler::Exception { using WP17Scheduler::Exception::Exception; }
+
+/**
+ * @brief Scheduler class 
+ * This class keeps track of events, threads and algorithms. 
+ * The constructor parameters a are:
+ * @param events Number of events
+ * @param threads number of threads
+ * @param slots Number of slots (i.e. concurrent events being processed, aso equal to the number of CUDA streams).
+ * @warning This class itself is not thread safe.
+ */
 class Scheduler {
 public:
+   /**
+    * @brief Scheduler constructor
+    * @param events Number of events
+    * @param threads number of threads
+    * @param slots Number of slots (i.e. concurrent events being processed).
+    */
    Scheduler(int events = 500, int threads = 4, int slots = 4);
+
+   // Forbidden constructors
    Scheduler(const Scheduler&) = delete;
    Scheduler& operator=(const Scheduler&) = delete;
+
+   /**
+    * @brief Destructor just cleans up the CUDA streams.
+    */
    ~Scheduler();
 
-   // Should this be a constant reference?
-   void addAlgorithm(AlgorithmBase& alg);
+   /** 
+    * @brief Adds an algorithm to the algorithm list. This function should be called before running. 
+    * @todo: Should this be a constant reference? 
+    */
+   void addAlgorithm(AlgorithmBase& alg); 
+
+   /** 
+    * @brief  Main scheduler loop
+    */
    StatusCode run();
+
+   /**
+    * @brief Sets the CUDA state to `state` for algorithm number `alg` on slot number `slot`.
+    * @param slot Slot index
+    * @param alg Algo index
+    * @param state `bool` state
+    * @todo Document BOOL meaning.
+    */
    void setCudaSlotState(int slot, std::size_t alg, bool state);
+
+   /**
+    * @brief Pushes the `update()` function in the action queue.
+    */
    void actionUpdate();
 
 private:
    using action_type = std::function<StatusCode()>;
 
-   // Internal state of the scheduler.
-   // Note that SlotState is movable but not copyable since AlgCoInterface is not copyable.
+   /**
+    * @brief Internal state of the scheduler for an individual even being processed.
+    * Note that SlotState is movable but not copyable since AlgCoInterface is not copyable.
+    * @todo The algorithm states should be a structure instead of a bunch of vectors accessed by the same index.
+    */
    struct SlotState {
+      /// Event ID being processed in this slot
       int eventNumber = 0;
+
+      /// CUDA status @todo Add details, `bool` meaning.
       std::vector<bool> cudaFinished{};
+
+      /// Algorithm results. Only valid if the algorithm is finished.
       std::vector<StatusCode> algStatuses{};
-      std::vector<AlgExecState> algStates{};
+
+      /// @todo Execution state of each algorithm in the slot.
+      std::vector<AlgExecState> algExecStates{};
+
+      /// @todo Add details.
       std::vector<AlgorithmBase::AlgCoInterface> coroutines{};
+
+      /// @todo Add details. Seems to handles algoritms dependencies and data object collection.
       std::unique_ptr<EventContentManager> eventManager{};
    };
 
+   /**
+    * @brief Assigns in initial event ids to each `slot` and creates the CUDA streams.
+    */
    void initSchedulerState();
+
+   /**
+    * @brief Call functor `f` synchronously. In case of failed status, wait for all tasks in the `m_group` task group to complete. 
+    * Asserts if the tasks were cancelled.
+    * @param f  `action_type` functor.
+    * @return `StatusCode` status.
+    * @todo Undestand how the other tasks are signaled to finish
+    */
    StatusCode executeAction(action_type& f);
+
+   /**
+    * @brief The workhorse of the scheduler. Processes each algo of slot at a time, in individual steps. This is one round of the 
+    * scheduling over each algo of each slot.
+    * 
+    * - If all algorithms in the slot are finished, it resets the slot state and prepares it for the next event (up tp m_events, the objective)
+    * 
+    * - Idle slots are expressed with an event number greater than or equal to `m_events`.
+    *
+    * - Then, in all cases errors are checked and reported (all errors are fatal).
+    * 
+    * - States which do not request action are skipped: SCHEDULED, FINISHED, ERROR, SUSPENDED without CUDA finished.
+    * 
+    * 
+    * @return Status for this round of scheduling.
+    */
    StatusCode update();
 
+   /**
+    * @brief Bottom half of `update()`. 
+    * 
+    * @param slot Slot for the currently processed event.
+    * @param ialg Algorithm index in the algorithm list.
+    * @param slotState Reference to the slot state that is being updated.
+    */
    void pushAction(int slot, std::size_t ialg, SlotState& slotState);
    void printStatuses() const;
 
    int m_events;
    int m_threads;
    int m_slots;
-   int m_nextEvent;
+   int m_nextEvent = 0;
+   bool m_runStarted = false;
    std::atomic_int m_remainingEvents;
 
    std::vector<std::reference_wrapper<AlgorithmBase>> m_algorithms;
 
    std::vector<SlotState> m_slotStates;
+   /**
+    * @brief Contains CUDA streams for each slot, in a one-to-one relationship.
+    * @todo It should simply be a member of SlotState.
+    */
    std::vector<cudaStream_t> m_streams;
 
    tbb::task_arena m_arena;
    tbb::task_group m_group;
-   tbb::concurrent_bounded_queue<action_type> m_actions;
+   tbb::concurrent_bounded_queue<action_type> m_actionQueue;
+public:
+   DEFINE_EXCEPTION(RuntimeError);
 };

--- a/src/Scheduler.hpp
+++ b/src/Scheduler.hpp
@@ -87,30 +87,36 @@ public:
 
 private:
    using action_type = std::function<StatusCode()>;
+   
+   /**
+    * @brief Internal state of the scheduler for each algorithm.
+    */
+   struct AlgorithmState {
+      /// CUDA status @todo Add details, `bool` meaning.
+      bool cudaFinished = false;
+
+      /// Algorithm results. Only valid if the algorithm is finished.
+      StatusCode status = StatusCode::SUCCESS;
+
+      /// @todo Execution state of each algorithm in the slot.
+      AlgExecState execState = AlgExecState::UNSCHEDULED;
+
+      /// Coroutine interface to algo execution. @todo Add details.
+      AlgorithmBase::AlgCoInterface coroutine;
+   };
 
    /**
     * @brief Internal state of the scheduler for an individual even being processed.
     * Note that SlotState is movable but not copyable since AlgCoInterface is not copyable.
-    * @todo The algorithm states should be a structure instead of a bunch of vectors accessed by the same index.
     */
    struct SlotState {
       /// Event ID being processed in this slot
       int eventNumber = 0;
-
-      /// CUDA status @todo Add details, `bool` meaning.
-      std::vector<bool> cudaFinished{};
-
-      /// Algorithm results. Only valid if the algorithm is finished.
-      std::vector<StatusCode> algStatuses{};
-
-      /// @todo Execution state of each algorithm in the slot.
-      std::vector<AlgExecState> algExecStates{};
-
-      /// @todo Add details.
-      std::vector<AlgorithmBase::AlgCoInterface> coroutines{};
-
+      /// States of the individual algorithms in the slot.
+      std::vector<AlgorithmState> algorithms;        // State of each algorithm in the slot.
+      
       /// @todo Add details. Seems to handles algoritms dependencies and data object collection.
-      std::unique_ptr<EventContentManager> eventManager{};
+      std::unique_ptr<EventContentManager> eventManager;
    };
 
    /**

--- a/src/StatusCode.hpp
+++ b/src/StatusCode.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-
 #include <iostream>
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <utility>
-
 
 #define SC_CHECK(EXP)                                             \
    do {                                                           \
@@ -15,7 +15,6 @@
       }                                                           \
    } while(false)
 
-
 #define SC_CHECK_YIELD(EXP)                                       \
    do {                                                           \
       const StatusCode sc = EXP;                                  \
@@ -25,7 +24,6 @@
       }                                                           \
    } while(false)
 
-
 class [[nodiscard]] StatusCode {
 public:
    enum class ErrorCode : int { SUCCESS = 0, FAILURE = 1 };
@@ -33,11 +31,46 @@ public:
    static constexpr ErrorCode SUCCESS = ErrorCode::SUCCESS;
    static constexpr ErrorCode FAILURE = ErrorCode::FAILURE;
 
+   // Default constructor
    StatusCode() = default;
-   StatusCode(const StatusCode&) = default;
-   StatusCode(StatusCode&&) = default;
-   StatusCode& operator=(const StatusCode&) = default;
-   StatusCode& operator=(StatusCode&&) = default;
+
+   // Copy constructor
+   StatusCode(const StatusCode& other) {
+      std::shared_lock<std::shared_mutex> lock(other.m_mutex); // Shared lock for thread-safe read
+      m_code = other.m_code;
+      m_msg = other.m_msg;
+   }
+
+   // Move constructor
+   StatusCode(StatusCode&& other) noexcept {
+      std::unique_lock<std::shared_mutex> lock(other.m_mutex); // Exclusive lock for thread-safe move
+      m_code = std::move(other.m_code);
+      m_msg = std::move(other.m_msg);
+   }
+
+   // Copy assignment operator
+   StatusCode& operator=(const StatusCode& other) {
+      if (this != &other) {
+         std::unique_lock<std::shared_mutex> lockThis(m_mutex, std::defer_lock);
+         std::shared_lock<std::shared_mutex> lockOther(other.m_mutex, std::defer_lock);
+         std::lock(lockThis, lockOther); // Lock both mutexes
+         m_code = other.m_code;
+         m_msg = other.m_msg;
+      }
+      return *this;
+   }
+
+   // Move assignment operator
+   StatusCode& operator=(StatusCode&& other) noexcept {
+      if (this != &other) {
+         std::unique_lock<std::shared_mutex> lockThis(m_mutex, std::defer_lock);
+         std::unique_lock<std::shared_mutex> lockOther(other.m_mutex, std::defer_lock);
+         std::lock(lockThis, lockOther); // Lock both mutexes
+         m_code = std::move(other.m_code);
+         m_msg = std::move(other.m_msg);
+      }
+      return *this;
+   }
 
    StatusCode(ErrorCode code, std::string msg)
        : m_code{code},
@@ -47,32 +80,50 @@ public:
    StatusCode(ErrorCode code) : m_code{code}, m_msg{""} {
    }
 
+   ~StatusCode() {
+      // Take the mutex exclusively during destruction
+      std::unique_lock<std::shared_mutex> lock(m_mutex);
+   }
+
    explicit operator bool() const {
+      // Shared lock for read access
+      std::shared_lock<std::shared_mutex> lock(m_mutex);
       return m_code == SUCCESS;
    }
 
    friend bool operator==(const StatusCode& status1, const StatusCode& status2) {
+      // Shared lock for read access
+      std::shared_lock<std::shared_mutex> lock1(status1.m_mutex);
+      std::shared_lock<std::shared_mutex> lock2(status2.m_mutex);
       return status1.m_code == status2.m_code;
    }
 
    friend bool operator!=(const StatusCode& status1, const StatusCode& status2) {
+      // Shared lock for read access
+      std::shared_lock<std::shared_mutex> lock1(status1.m_mutex);
+      std::shared_lock<std::shared_mutex> lock2(status2.m_mutex);
       return !(status1 == status2);
    }
 
    const std::string& appendMsg(const std::string& s) {
+      // Exclusive lock for modifying the message
+      std::unique_lock<std::shared_mutex> lock(m_mutex);
       return m_msg += std::string{"\n"} += "***** " + s + " *****";
    }
 
    std::string what() const {
-      if(m_code == SUCCESS && m_msg.empty()) {
+      // Shared lock for read access
+      std::shared_lock<std::shared_mutex> lock(m_mutex);
+      if (m_code == SUCCESS && m_msg.empty()) {
          return "<<<<< SUCCESS >>>>>";
-      } else if(m_code == FAILURE && m_msg.empty()) {
+      } else if (m_code == FAILURE && m_msg.empty()) {
          return "<<<<< FAILURE >>>>>";
       }
       return m_msg;
    }
 
 private:
+   mutable std::shared_mutex m_mutex; // Mutex for thread safety
    ErrorCode m_code{SUCCESS};
    std::string m_msg{};
 };

--- a/src/StatusCode.hpp
+++ b/src/StatusCode.hpp
@@ -8,8 +8,8 @@
 
 #define SC_CHECK(EXP)                                             \
    do {                                                           \
-      const auto sc = EXP;                                        \
-      if(!sc.isSuccess()) {                                       \
+      const StatusCode sc = EXP;                                  \
+      if(!sc) {                                                   \
          std::cout << "Failed to execute: " << #EXP << std::endl; \
          return StatusCode::FAILURE;                              \
       }                                                           \
@@ -18,8 +18,8 @@
 
 #define SC_CHECK_YIELD(EXP)                                       \
    do {                                                           \
-      const auto sc = EXP;                                        \
-      if(!sc.isSuccess()) {                                       \
+      const StatusCode sc = EXP;                                  \
+      if(!sc) {                                                   \
          std::cout << "Failed to execute: " << #EXP << std::endl; \
          co_yield StatusCode::FAILURE;                            \
       }                                                           \
@@ -49,14 +49,6 @@ public:
 
    explicit operator bool() const {
       return m_code == SUCCESS;
-   }
-
-   bool isSuccess() const {
-      return m_code == SUCCESS;
-   }
-
-   bool isFailure() const {
-      return m_code == FAILURE;
    }
 
    friend bool operator==(const StatusCode& status1, const StatusCode& status2) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-enable_testing()
-
 add_executable(TestEventStore TestEventStore.cpp)
 target_link_libraries(TestEventStore PRIVATE CoScheduler)
 add_test(NAME TestEventStore COMMAND TestEventStore)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_executable(TestEventStore TestEventStore.cpp)
 target_link_libraries(TestEventStore PRIVATE CoScheduler)
 add_test(NAME TestEventStore COMMAND TestEventStore)
+
+## TBB tests
+add_executable(TestTBBTaskSuspension TestTBBTaskSuspension.cpp)
+target_link_libraries(TestTBBTaskSuspension PUBLIC TBB::tbb CUDA::cudart) 

--- a/tests/NVTXUtils.hpp
+++ b/tests/NVTXUtils.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <nvtx3/nvtx3.hpp>
+
+/**
+ * @brief Utilities for NVTX instrumentation.
+ */
+namespace WP17Scheduler::NVTXUtils {
+  /**
+   * @brief Generates cycling colors based on an index/event id.
+   * @tparam T Index type
+   * @param i index value
+   * @return nxtv3::rgb Color, one value per index/event.
+   */
+  template <typename T>
+  inline nvtx3::rgb nvtxcolor(T i) {
+    constexpr nvtx3::rgb CERNBlue{0, 51, 160};
+    uint8_t r = ((i * 23)+ CERNBlue.red)   & 0xFF;
+    uint8_t g = ((i * 47)+ CERNBlue.green) & 0xFF;
+    uint8_t b = ((i * 71)+ CERNBlue.blue)  & 0xFF;
+    return nvtx3::rgb{r, g, b};
+  }
+}

--- a/tests/TestTBBTaskSuspension.cpp
+++ b/tests/TestTBBTaskSuspension.cpp
@@ -1,0 +1,38 @@
+/**
+ * @file TestTBBTaskSuspention.cpp
+ * @brief Test for TBB task suspension as an alternative to coroutines.
+ */
+
+#include <tbb/task.h>
+#include <tbb/task_group.h>
+#include <tbb/task_arena.h>
+#include <iostream>
+#include <ranges>
+#include <chrono>
+using namespace std::chrono_literals;
+#include "NVTXUtils.hpp"
+using WP17Scheduler::NVTXUtils::nvtxcolor;
+using nvtx3::scoped_range;
+
+int main () {
+    tbb::task_arena arena(4); // Create an arena with 4 threads
+
+    arena.execute([] {
+        tbb::task_group g;
+
+        for (auto i: std::views::iota(0, 100)) {
+            g.run([i]() {
+                nvtx3::unique_range range{"Task " + std::to_string(i), nvtxcolor(i), nvtx3::payload{i}};
+                // std::cout << "Task " << i << " started\n";
+                std::this_thread::sleep_for(50ms + (i % 10) * 10ms); // Simulate work
+                // std::cout << "Task " << i << " completed\n";
+            });
+        }
+
+        g.wait(); // Wait for all tasks to complete
+    });
+
+    std::cout << "All tasks completed\n";
+    return 0;
+}
+

--- a/tests/extract_suppressions.py
+++ b/tests/extract_suppressions.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import re
+import sys
+from collections import defaultdict
+
+def extract_suppressions(file_path):
+    """
+    Extract suppression lists from Helgrind output, count occurrences, and print each suppression with its count.
+
+    :param file_path: Path to the file containing Helgrind output
+    """
+    # Regular expression to match suppression blocks
+    suppression_start_pattern = r"^{"
+    suppression_end_pattern = r"^}$"
+
+    # Dictionary to store suppression blocks and their counts
+    suppressions = defaultdict(int)
+
+    with open(file_path, 'r') as file:
+        lines = file.readlines()
+
+    inside_suppression = False
+    current_suppression = []
+
+    for line in lines:
+        line = line.rstrip()  # Remove trailing whitespace
+
+        if re.match(suppression_start_pattern, line):
+            inside_suppression = True
+            current_suppression = [line]
+        elif inside_suppression:
+            current_suppression.append(line)
+            if re.match(suppression_end_pattern, line):
+                inside_suppression = False
+                # Join the suppression block into a single string
+                suppression_block = "\n".join(current_suppression)
+                # Increment the count for this suppression block
+                suppressions[suppression_block] += 1
+
+    # Print each unique suppression block with its count
+    print("Unique Suppressions and Counts:")
+    for suppression, count in suppressions.items():
+        print(f"\nCount: {count}\nSuppression:\n{suppression}")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: ./extract_suppressions.py <helgrind_output_file>")
+        print("Extracts and counts unique suppression lists from Helgrind output.")
+        sys.exit(1)
+
+    helgrind_output_file = sys.argv[1]
+    extract_suppressions(helgrind_output_file)

--- a/tests/helgrind.suppr
+++ b/tests/helgrind.suppr
@@ -1,0 +1,49 @@
+{
+   Device_drivers
+   Helgrind:Race
+   ...
+   obj:/usr/lib/wsl/drivers/nv_dispi.inf_amd64_a991e39d9975490a/libcuda.so.1.1
+}
+
+{
+   TBB_private_worker
+   Helgrind:Race
+   ...
+   fun:_ZN3tbb6detail2r13rml14private_worker14thread_routineEPv
+}
+
+{
+   task_arena_impl::execute
+   Helgrind:Race
+   ...
+   fun:_ZN3tbb6detail2r115task_arena_impl7executeERNS0_2d115task_arena_baseERNS3_13delegate_baseE
+}
+
+{
+   tbb::detail::r1::wait_bounded_queue_monitor
+   Helgrind:Race
+   ...
+   fun:_ZN3tbb6detail2r126wait_bounded_queue_monitorEPNS1_18concurrent_monitorEmlRNS0_2d113delegate_baseE
+}
+
+{
+   not_std::atomics_ops
+   Helgrind:Race
+   ...
+   fun:load
+}
+
+{
+   not_std::atomics_ops2
+   Helgrind:Race
+   ...
+   fun:store
+}
+
+{
+   TBB_usage
+   Helgrind:Race
+   ...
+   fun:pop
+   fun:_ZN9Scheduler3runEv
+}


### PR DESCRIPTION
The rehaul documents and comments the code of the coroutine based scheduler. 
The scheduler can now be run with multiple parameter set from the command line. It is functional (unneeded sync stream is now removed). The sync stream was probably hiding race conditions in the shared data structures. Although all seems to run fine, the helgrind report is not clear yet.

A new utility script now runs a performance can (`<build>/bin/simple_scheduler_scan.sh`)

This PR is a WIP, and will be released when helgrind comes out clean.